### PR TITLE
feat(governance): adopt QWED ecosystem policy framework — QWED_RULES.md, copilot instructions, PR template, CONTRIBUTING.md, coderabbit, boundary check

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,34 @@
+# Root of qwed-infra
+language: en-US
+reviews:
+  instructions: |
+    Follow QWED_RULES.md strictly.
+
+    QWED-Infra is a deterministic verification engine for Infrastructure as Code,
+    not a conventional application. Do not suggest changes that weaken enforcement
+    in exchange for convenience, usability, or availability.
+
+    Reject suggestions that introduce or recommend:
+    - fallback execution
+    - graceful degradation past failed verification
+    - raw eval/exec as backup behavior
+    - retries or auto-correction that bypass verification
+    - trust in model output as proof
+    - scoring or confidence heuristics for enforcement decisions
+
+    Prefer fail-closed behavior and default-deny handling.
+  auto_review:
+    enabled: true
+  path_instructions:
+    - path: "**/*.py"
+      instructions: |
+        You are a security auditor for QWED-Infra (Deterministic IaC Verification).
+
+        Follow QWED_RULES.md strictly.
+
+        CRITICAL RULES:
+        1. NO EVAL/EXEC: Block any eval(), exec(), os.system(), or subprocess calls — use native Python SDK instead.
+        2. IAM VERIFICATION: IAM policy logic must use Z3 SMT solver, not regex or string matching.
+        3. NETWORK VERIFICATION: Network reachability must use graph traversal (NetworkX), not port-matching alone.
+        4. COST FAIL-CLOSED: Unknown instance types must cause fail-closed (within_budget=False), not silent skip.
+        5. VULNERABILITY FAMILIES: If you find one bypass pattern, assume the entire class is exploitable until an explicit guard exists.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,20 @@
+# Copilot Instructions for QWED-Infra
+
+Read and follow [QWED_RULES.md](../QWED_RULES.md) for every suggestion.
+
+Additional repository-specific rules:
+
+- Do not suggest fallback execution paths.
+- Do not suggest graceful degradation that continues past failed verification.
+- Do not suggest retries that weaken enforcement.
+- Do not trust model output as proof of correctness.
+- Do not use scoring, confidence thresholds, or heuristics for decisions.
+- Do not suggest `eval` / `exec` / `subprocess` outside approved wrappers.
+- Prefer fail-closed behavior over convenience or availability.
+- IAM policies must be verified with Z3 — regex-based checks are not sufficient.
+- Network rules must prove reachability via graph traversal, not port matching alone.
+- Unknown instance types in cost estimation must fail closed, not silently continue.
+- Treat unresolved vulnerabilities as still critical — new layers are additive.
+
+If a suggestion conflicts with QWED enforcement rules, the suggestion must be
+rejected.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## QWED Enforcement Checklist
+
+- [ ] Verification before execution — no path bypasses verification
+- [ ] Fail closed — all failure paths block, not degrade
+- [ ] Approved paths only — no bare `eval` / `exec` / `subprocess`
+- [ ] No silent degradation — no suppressed errors or bypass-oriented retries
+- [ ] IAM policies verified with Z3 (regex-only checks are not sufficient)
+- [ ] Network reachability proven via graph traversal, not port matching alone
+- [ ] Cost estimation fails closed on unknown instance types
+- [ ] Vulnerability family thinking — similar bypass patterns considered
+- [ ] Existing issues not regressed — severity of unfixed issues unchanged
+
+## Summary
+
+Describe the intent of the change and the verification boundary it touches.
+
+## Validation
+
+List the checks, tests, or scans used to validate this PR.
+
+## Notes
+
+If this change affects enforcement behavior, explain why it is still compliant
+with [QWED_RULES.md](../QWED_RULES.md).

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -36,6 +36,7 @@ jobs:
           pytest --cov=qwed_infra --cov-report=xml --cov-report=term-missing tests/ || true
 
       - name: SonarCloud Scan
+        continue-on-error: true
         uses: SonarSource/sonarqube-scan-action@bfd4e558cda28cda6b5defafb9232d191be8c203 # v4.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -35,8 +35,14 @@ jobs:
         run: |
           pytest --cov=qwed_infra --cov-report=xml --cov-report=term-missing tests/ || true
 
+      - name: Check Sonar token
+        id: sonar_token_check
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: echo "configured=${{ env.SONAR_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
+
       - name: SonarCloud Scan
-        continue-on-error: true
+        if: steps.sonar_token_check.outputs.configured == 'true'
         uses: SonarSource/sonarqube-scan-action@bfd4e558cda28cda6b5defafb9232d191be8c203 # v4.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -41,6 +41,11 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: echo "configured=${{ env.SONAR_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
 
+      - name: Enforce Sonar token on trusted events
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          test "${{ steps.sonar_token_check.outputs.configured }}" = "true"
+
       - name: SonarCloud Scan
         if: steps.sonar_token_check.outputs.configured == 'true'
         uses: SonarSource/sonarqube-scan-action@bfd4e558cda28cda6b5defafb9232d191be8c203 # v4.2.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Boundary Check (QWED Rules)
+        run: python scripts/check_boundary.py
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ git push origin feat/your-feature
 
 ### Commit Message Format
 
-```
+```text
 type(scope): description
 
 feat(iam): add condition key wildcard matching
@@ -120,7 +120,7 @@ docs: update architecture diagram
 
 ## Repository Structure
 
-```
+```text
 qwed-infra/
 ├── qwed_infra/
 │   ├── guards/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,141 @@
+# Contributing to QWED-Infra
+
+> **QWED-Infra** = Deterministic Verification for Infrastructure as Code (IaC)
+
+Thank you for your interest in contributing! Before you start, please read this guide to understand QWED's philosophy and avoid common misunderstandings.
+
+---
+
+## Required Reading (Before Contributing)
+
+| File | Why It Matters |
+|------|----------------|
+| [README.md](./README.md) | Understand what QWED-Infra is |
+| [QWED_RULES.md](./QWED_RULES.md) | Canonical enforcement rules for contributors and tools |
+
+---
+
+## Understanding QWED's Philosophy
+
+### The Core Principle: Deterministic First
+
+QWED-Infra is NOT a linter, a static analysis tool, or a best-practice checker.
+
+1. **IAM policies are logical formulas** - Z3 SMT solver proves whether access is allowed or denied
+2. **Network topologies are graphs** - NetworkX traverses routes, Security Groups are firewall rules
+3. **Costs are arithmetic** - Pricing catalog + instance count = deterministic estimate
+4. **LLM output is never proof** - No model fallback for verification decisions
+
+### Approved Paths
+
+Sensitive operations must go through approved wrappers:
+
+| Dangerous Operation | Approved Path |
+|---------------------|---------------|
+| `eval()` / `exec()` | Not needed — use Z3/NetworkX/arithmetic directly |
+| `os.system()` / `subprocess.Popen()` | Blocked — use native Python SDK |
+| `hcl2.load()` | Approved parser path for Terraform files |
+
+### Common Misunderstandings
+
+| Wrong Approach | Correct Approach |
+|----------------|------------------|
+| "Let the LLM review the IAM policy" | Use Z3 to prove allow/deny |
+| "Check port 22 in the SG string" | Use graph reachability analysis |
+| "Regex for wildcard IAM actions" | Use Z3 pattern matching with `InRe` |
+| "Skip cost check for unknown instance types" | Fail closed — unknown = blocked |
+
+---
+
+## Development Setup
+
+```bash
+# Clone the repo
+git clone https://github.com/QWED-AI/qwed-infra.git
+cd qwed-infra
+
+# Create virtual environment
+python -m venv venv
+source venv/bin/activate  # or .\venv\Scripts\activate on Windows
+
+# Install in development mode
+pip install -e ".[dev]"
+
+# Run tests
+pytest tests/ -v
+```
+
+---
+
+## How to Contribute
+
+### 1. Reporting Bugs
+
+Open an issue with:
+- Python version
+- Input that caused the bug
+- Expected vs actual result
+- Which guard is affected (IAM, Network, Cost, Parser)
+
+### 2. Proposing Features
+
+Before coding, open an issue to discuss:
+- What problem does it solve?
+- Does it require LLM or is it deterministic?
+- Which guard does it affect?
+
+### 3. Submitting Pull Requests
+
+```bash
+# 1. Fork and clone
+git clone https://github.com/YOUR_USERNAME/qwed-infra.git
+
+# 2. Create a branch
+git checkout -b feat/your-feature
+
+# 3. Make changes
+
+# 4. Run tests
+pytest tests/ -v
+
+# 5. Commit with conventional commits
+git commit -m "feat(guard): add S3 bucket policy verification"
+
+# 6. Push and create PR
+git push origin feat/your-feature
+```
+
+### Commit Message Format
+
+```
+type(scope): description
+
+feat(iam): add condition key wildcard matching
+fix(network): handle NAT gateway routes
+test(cost): add edge case for zero instances
+docs: update architecture diagram
+```
+
+---
+
+## Repository Structure
+
+```
+qwed-infra/
+├── qwed_infra/
+│   ├── guards/
+│   │   ├── iam_guard.py       # Z3-based IAM policy verification
+│   │   ├── network_guard.py   # NetworkX-based reachability analysis
+│   │   └── cost_guard.py      # Deterministic cost estimation
+│   └── parsers/
+│       └── terraform_parser.py # HCL2 Terraform file parser
+├── tests/                     # Unit tests
+├── demo/                      # Usage demo
+└── docs/                      # Documentation
+```
+
+---
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [Apache 2.0 License](./LICENSE).

--- a/QWED_RULES.md
+++ b/QWED_RULES.md
@@ -33,12 +33,12 @@ Verification is the primary operation. Execution happens only after verification
 succeeds.
 
 **Allowed:**
-```
+```text
 Input → Verify → Execute
 ```
 
 **Forbidden:**
-```
+```text
 Input → Execute → Verify later
 ```
 

--- a/QWED_RULES.md
+++ b/QWED_RULES.md
@@ -1,91 +1,160 @@
-# QWED Enforcement Rules
+# QWED Ecosystem Enforcement Rules
 
-QWED is not a conventional application. It is a deterministic verification and
-enforcement boundary.
+QWED is not an AI model. QWED is not an agent framework.
+QWED is not a trust scoring system. QWED is not an orchestration platform.
+
+QWED is a **deterministic verification and enforcement ecosystem**.
+
+Its purpose is to create verifiable boundaries around AI systems, tools, agents,
+workflows, and machine-generated outputs. The goal is not to make AI smarter.
+The goal is to make AI behavior more governable, auditable, predictable, and
+enforceable.
 
 These rules are non-negotiable for contributors, reviewers, and automation
 tools operating on this repository.
 
-## Core Principles
+---
 
-### 1. Verification Before Execution
+## Priority Order
 
-No execution path may bypass verification. Every operation that produces output
-or triggers a side effect must first pass a deterministic verification gate.
-No exceptions for "safe enough" shortcuts.
+1. Determinism
+2. Safety
+3. Control
+4. Accountability
+5. Convenience
 
-### 2. Fail Closed
+Convenience must never override verification.
 
-If verification or enforcement fails—for any reason—the operation must block.
-Availability is secondary to correctness and containment. A false positive
-(rejecting a valid request) is always preferable to a false negative (passing
-an invalid one).
+---
 
-### 3. Deterministic Decisions
+## Principle 1 — Verification Before Execution
 
-All enforcement decisions must be based on deterministic rules—not scoring,
-confidence thresholds, heuristics, or probabilistic models. If two independent
-runs of the enforcement logic on the same input could produce different results,
-the design is wrong.
+Verification is the primary operation. Execution happens only after verification
+succeeds.
 
-### 4. Explicit Boundaries
+**Allowed:**
+```
+Input → Verify → Execute
+```
 
-Every security or verification boundary must be explicitly defined at the
-architectural level. Implicit boundaries (e.g., "the LLM will not output X
-because we prompted it not to") are not boundaries. A boundary must be
-testable, measurable, and auditable.
+**Forbidden:**
+```
+Input → Execute → Verify later
+```
 
-### 5. Approved Paths Only
+## Principle 2 — Fail Closed
 
-Sensitive operations must be routed through explicit, pre-approved wrapper
-functions. Direct calls to `eval`, `exec`, `os.system`, or `subprocess` are
-forbidden outside approved wrappers.
+When verification cannot prove correctness: **BLOCK**.
 
-### 6. No Silent Degradation
+Not: retry, guess, trust, approximate, or continue anyway.
 
-If a component cannot fulfill its enforcement responsibility, it must fail
-loudly. Do not suppress errors. Do not auto-correct, auto-retry, or continue
-execution in a degraded mode. Silent degradation is a vulnerability in waiting.
+Unverifiable is safer than incorrectly verified.
 
-### 7. Security Boundaries Are First-Class
+## Principle 3 — Deterministic Decisions
 
-Security and verification boundaries are not optional features. They must be
-on by default, server-side, and not configurable or bypassable by user input.
-The user cannot opt out of enforcement.
+The system avoids confidence scores, trust scores, reputation systems,
+probabilistic approvals, and heuristic risk weighting.
 
-### 8. Verify Claims, Not Sources
+**Allowed:** PASS, FAIL, UNVERIFIABLE
+**Forbidden:** "85% trusted", "Probably safe", "Likely correct"
 
-Claims must be verified by deterministic computation, not by the source of the
-claim. LLM outputs, confidence scores, reasoning chains, and metadata are
-inputs to the verification pipeline—they are not proof. Trust comes from
-deterministic verification, not from origin.
+## Principle 4 — Explicit Boundaries
 
-### 9. Ecosystem Neutrality
+Every security boundary must be explicit: parser boundary, verification
+boundary, execution boundary, network boundary, cloud boundary.
 
-QWED rules apply regardless of the model provider, framework, or deployment
-environment. No LLM-specific behavior may be relied upon for enforcement —
-only documented, deterministic behaviors.
+Crossing a boundary requires verification. Implicit trust is prohibited.
 
-### 10. Hardening Over Features
+## Principle 5 — Approved Paths Only
 
-Hardening, boundary enforcement, and vulnerability mitigation take priority
-over feature velocity. Treat security debt as functional debt. Do not trade
-long-term safety for short-term convenience.
+Security-sensitive operations must use approved pathways.
 
-### 11. Vulnerability Family Thinking
+**Allowed:** `hcl2.load()` (structured parser)
+**Forbidden:** `eval()`, `exec()`, `os.system()`, `subprocess.Popen()`
 
-Do not patch individual symptoms; fix the vulnerability family. When a single
-eval-like pattern is found, assume the entire category of similar bypasses is
-exploitable until proven otherwise by an explicit, deterministic guard.
+The existence of a safe boundary automatically makes direct bypasses
+architecture violations.
 
-### 12. Existing Issues Must Survive New Boundaries
+## Principle 6 — No Silent Degradation
 
-Introducing a new boundary or security layer must not reduce the severity of
-existing, unfixed security issues. All existing vulnerabilities retain their
-priority until resolved. New enforcement layers are additive, not
-substitutional.
+A system must not quietly downgrade security.
 
-## Forbidden Suggestions
+**Forbidden:**
+- Try strict → fail → fallback mode
+- Try verifier A → fail → verifier B
+- Try parser A → fail → parser B
+- Try validation → ignore error
+
+Failures must remain visible.
+
+## Principle 7 — Security Boundaries Are First-Class Features
+
+Security is not documentation. Security is not optional configuration. Security
+boundaries must be enforceable in code, tests, CI, releases, and deployment
+workflows.
+
+Every security boundary must have tests, regression tests, release gates, and
+CI enforcement.
+
+## Principle 8 — Verify Claims, Not Sources
+
+QWED evaluates claims. QWED does not evaluate authority. The identity of a
+source never replaces verification.
+
+**Forbidden:** "OpenAI said it.", "Trusted partner approved it."
+**Allowed:** "The claim was independently verified."
+
+## Principle 9 — Ecosystem Neutrality
+
+QWED is model-agnostic. It must not depend on any specific provider.
+
+Model providers are interchangeable. Verification remains constant.
+
+## Principle 10 — Hardening Over Features
+
+When choosing between a new capability and a stronger verification boundary,
+prefer the boundary.
+
+Verification debt is more dangerous than feature debt.
+
+## Principle 11 — Vulnerability Family Thinking
+
+Do not patch only the reported bug. Identify and fix the entire vulnerability
+family.
+
+**Example:** An unsafe execution sink requires reviewing all execution sinks,
+all parser boundaries, and all dynamic invocation patterns.
+
+A fix is incomplete if equivalent attack paths remain.
+
+## Principle 12 — Existing Issues Must Survive New Security Boundaries
+
+Before implementing any issue, ask: "Can this change bypass a security boundary
+introduced after the issue was created?" If yes, update the issue first.
+
+Security boundaries introduced later take precedence over historical issue text.
+
+---
+
+## Review Rule
+
+For every PR, issue, audit, feature request, architecture proposal, or
+contributor submission, evaluate:
+
+1. Does it strengthen or weaken verification?
+2. Does it preserve fail-closed behavior?
+3. Does it introduce trust, scoring, probability, heuristics, or aggregation?
+4. Does it bypass an approved boundary?
+5. Does it create silent degradation?
+6. Does it expand the vulnerability family?
+7. Does it remain model-agnostic?
+8. Does it increase governance and accountability?
+
+If uncertain: **Reject, block, or mark UNVERIFIABLE.**
+
+---
+
+## Forbidden Suggestion Patterns
 
 - "Add fallback for reliability"
 - "Gracefully handle failure by continuing execution"
@@ -93,17 +162,4 @@ substitutional.
 - "Trust model output if confidence is high"
 - "Retry automatically until success"
 - "Allow temporary bypass until the verifier is available"
-- "Score LLM outputs and accept if above N% confidence"
-- "Rely on system prompt to prevent X from happening"
-
-## Decision Rule
-
-If a change improves usability, convenience, or availability but weakens
-enforcement, reject the change.
-
-Priority order:
-
-1. Determinism
-2. Safety
-3. Control
-4. Everything else
+- "Use scoring/trust/reputation to decide"

--- a/QWED_RULES.md
+++ b/QWED_RULES.md
@@ -1,0 +1,109 @@
+# QWED Enforcement Rules
+
+QWED is not a conventional application. It is a deterministic verification and
+enforcement boundary.
+
+These rules are non-negotiable for contributors, reviewers, and automation
+tools operating on this repository.
+
+## Core Principles
+
+### 1. Verification Before Execution
+
+No execution path may bypass verification. Every operation that produces output
+or triggers a side effect must first pass a deterministic verification gate.
+No exceptions for "safe enough" shortcuts.
+
+### 2. Fail Closed
+
+If verification or enforcement fails—for any reason—the operation must block.
+Availability is secondary to correctness and containment. A false positive
+(rejecting a valid request) is always preferable to a false negative (passing
+an invalid one).
+
+### 3. Deterministic Decisions
+
+All enforcement decisions must be based on deterministic rules—not scoring,
+confidence thresholds, heuristics, or probabilistic models. If two independent
+runs of the enforcement logic on the same input could produce different results,
+the design is wrong.
+
+### 4. Explicit Boundaries
+
+Every security or verification boundary must be explicitly defined at the
+architectural level. Implicit boundaries (e.g., "the LLM will not output X
+because we prompted it not to") are not boundaries. A boundary must be
+testable, measurable, and auditable.
+
+### 5. Approved Paths Only
+
+Sensitive operations must be routed through explicit, pre-approved wrapper
+functions. Direct calls to `eval`, `exec`, `os.system`, or `subprocess` are
+forbidden outside approved wrappers.
+
+### 6. No Silent Degradation
+
+If a component cannot fulfill its enforcement responsibility, it must fail
+loudly. Do not suppress errors. Do not auto-correct, auto-retry, or continue
+execution in a degraded mode. Silent degradation is a vulnerability in waiting.
+
+### 7. Security Boundaries Are First-Class
+
+Security and verification boundaries are not optional features. They must be
+on by default, server-side, and not configurable or bypassable by user input.
+The user cannot opt out of enforcement.
+
+### 8. Verify Claims, Not Sources
+
+Claims must be verified by deterministic computation, not by the source of the
+claim. LLM outputs, confidence scores, reasoning chains, and metadata are
+inputs to the verification pipeline—they are not proof. Trust comes from
+deterministic verification, not from origin.
+
+### 9. Ecosystem Neutrality
+
+QWED rules apply regardless of the model provider, framework, or deployment
+environment. No LLM-specific behavior may be relied upon for enforcement —
+only documented, deterministic behaviors.
+
+### 10. Hardening Over Features
+
+Hardening, boundary enforcement, and vulnerability mitigation take priority
+over feature velocity. Treat security debt as functional debt. Do not trade
+long-term safety for short-term convenience.
+
+### 11. Vulnerability Family Thinking
+
+Do not patch individual symptoms; fix the vulnerability family. When a single
+eval-like pattern is found, assume the entire category of similar bypasses is
+exploitable until proven otherwise by an explicit, deterministic guard.
+
+### 12. Existing Issues Must Survive New Boundaries
+
+Introducing a new boundary or security layer must not reduce the severity of
+existing, unfixed security issues. All existing vulnerabilities retain their
+priority until resolved. New enforcement layers are additive, not
+substitutional.
+
+## Forbidden Suggestions
+
+- "Add fallback for reliability"
+- "Gracefully handle failure by continuing execution"
+- "Use eval/exec as backup"
+- "Trust model output if confidence is high"
+- "Retry automatically until success"
+- "Allow temporary bypass until the verifier is available"
+- "Score LLM outputs and accept if above N% confidence"
+- "Rely on system prompt to prevent X from happening"
+
+## Decision Rule
+
+If a change improves usability, convenience, or availability but weakens
+enforcement, reject the change.
+
+Priority order:
+
+1. Determinism
+2. Safety
+3. Control
+4. Everything else

--- a/scripts/check_boundary.py
+++ b/scripts/check_boundary.py
@@ -24,6 +24,10 @@ FORBIDDEN_CALLS = {
     "popen",
 }
 
+# Bare leaf names of forbidden calls — catches import-alias bypasses
+# e.g. `from subprocess import run; run("cmd")` produces bare `run` not `subprocess.run`
+FORBIDDEN_LEAF_NAMES = {name.split(".")[-1] for name in FORBIDDEN_CALLS}
+
 
 def get_call_names(node: ast.Call) -> list[str]:
     names = []
@@ -38,7 +42,8 @@ def get_call_names(node: ast.Call) -> list[str]:
         if isinstance(current, ast.Name):
             parts.append(current.id)
         elif isinstance(current, ast.Call):
-            return names
+            # Chained call like get_runner().run(...) — can't extract base name
+            pass
         names.append(".".join(reversed(parts)))
     return names
 
@@ -75,12 +80,20 @@ def check_file(filepath: Path) -> list[str]:
                         f"Disallowed call '{name}()'"
                     )
 
-            # os.system, subprocess.*, popen
+            # os.system, subprocess.*, popen (dotted names)
             if name in FORBIDDEN_CALLS:
                 errors.append(
                     f"  [BARE_SHELL] {relpath}:{node.lineno}: "
                     f"Disallowed call '{name}()'"
                 )
+
+            # Import-alias bypass: from subprocess import run; run("cmd")
+            if "." not in name and leaf in FORBIDDEN_LEAF_NAMES:
+                if leaf not in {"eval", "exec"}:
+                    errors.append(
+                        f"  [BARE_SHELL] {relpath}:{node.lineno}: "
+                        f"Disallowed bare call '{name}()' — possible import alias"
+                    )
 
     return errors
 

--- a/scripts/check_boundary.py
+++ b/scripts/check_boundary.py
@@ -58,6 +58,18 @@ def _build_alias_map(tree: ast.Module) -> dict[str, str]:
         elif isinstance(node, ast.ImportFrom):
             module = node.module or ""
             for alias in node.names:
+                if alias.name == "*":
+                    if module == "subprocess":
+                        for call in FORBIDDEN_CALLS:
+                            if call.startswith("subprocess."):
+                                alias_map[call.split(".", 1)[1]] = call
+                    elif module == "os":
+                        alias_map["system"] = "os.system"
+                        alias_map["popen"] = "os.popen"
+                    elif module == "builtins":
+                        alias_map["eval"] = "builtins.eval"
+                        alias_map["exec"] = "builtins.exec"
+                    continue
                 local = alias.asname or alias.name
                 full = f"{module}.{alias.name}" if module else alias.name
                 alias_map[local] = full
@@ -85,6 +97,18 @@ def check_file(filepath: Path) -> list[str]:
         if not isinstance(node, ast.Call):
             continue
 
+        # Check for shell=True on every call node, even unresolvable ones
+        if any(
+            keyword.arg == "shell"
+            and isinstance(keyword.value, ast.Constant)
+            and keyword.value.value is True
+            for keyword in node.keywords
+        ):
+            errors.append(
+                f"  [SHELL_TRUE] {relpath}:{node.lineno}: "
+                "Disallowed shell=True argument"
+            )
+
         call_names = get_call_names(node)
         if not call_names:
             continue
@@ -106,7 +130,7 @@ def check_file(filepath: Path) -> list[str]:
 
             # bare eval/exec → always dangerous (resolved catches aliased imports)
             if leaf in {"eval", "exec"}:
-                if "." not in resolved or resolved.startswith("builtins."):
+                if "." not in resolved or resolved.startswith("builtins.") or resolved.startswith("__builtins__."):
                     errors.append(
                         f"  [BARE_EVAL] {relpath}:{node.lineno}: "
                         f"Disallowed call '{name}()'"

--- a/scripts/check_boundary.py
+++ b/scripts/check_boundary.py
@@ -10,7 +10,8 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
-SRC_DIR = REPO_ROOT / "qwed_infra"
+SCAN_ROOT = REPO_ROOT
+EXCLUDED_DIRS = {".git", ".venv", "venv", "__pycache__", ".mypy_cache", ".pytest_cache"}
 
 # Full call names that are forbidden (dotted names)
 FORBIDDEN_CALLS = {
@@ -46,6 +47,23 @@ def get_call_names(node: ast.Call) -> list[str]:
     return names
 
 
+def _build_alias_map(tree: ast.Module) -> dict[str, str]:
+    """Build map of local name → original dotted name from import statements."""
+    alias_map = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                local = alias.asname or alias.name
+                alias_map[local] = alias.name
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for alias in node.names:
+                local = alias.asname or alias.name
+                full = f"{module}.{alias.name}" if module else alias.name
+                alias_map[local] = full
+    return alias_map
+
+
 def check_file(filepath: Path) -> list[str]:
     errors = []
     try:
@@ -57,7 +75,11 @@ def check_file(filepath: Path) -> list[str]:
         )
         return errors
 
-    relpath = filepath.relative_to(REPO_ROOT).as_posix()
+    try:
+        relpath = filepath.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        relpath = filepath.as_posix()
+    alias_map = _build_alias_map(tree)
 
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
@@ -68,25 +90,27 @@ def check_file(filepath: Path) -> list[str]:
             continue
 
         for name in call_names:
-            leaf = name.split(".")[-1]
+            # Resolve through import alias map to catch bypasses
+            resolved = alias_map.get(name, name)
+            leaf = resolved.split(".")[-1]
 
-            # bare eval/exec → always dangerous
+            # bare eval/exec → always dangerous (resolved catches aliased imports)
             if leaf in {"eval", "exec"}:
-                if "." not in name or name.startswith("builtins."):
+                if "." not in resolved or resolved.startswith("builtins."):
                     errors.append(
                         f"  [BARE_EVAL] {relpath}:{node.lineno}: "
                         f"Disallowed call '{name}()'"
                     )
 
-            # os.system, subprocess.*, popen (dotted names)
-            if name in FORBIDDEN_CALLS:
+            # os.system, subprocess.*, popen (dotted or alias-resolved names)
+            if resolved in FORBIDDEN_CALLS:
                 errors.append(
                     f"  [BARE_SHELL] {relpath}:{node.lineno}: "
                     f"Disallowed call '{name}()'"
                 )
 
-            # Import-alias bypass: from subprocess import run; run("cmd")
-            # Skip if already caught by the dotted-name check above (prevents double-report)
+            # Unresolved bare leaf name — possible import alias bypass
+            # Skip if already caught above (prevents double-report for e.g. popen)
             elif "." not in name and name in FORBIDDEN_LEAF_NAMES:
                 errors.append(
                     f"  [BARE_SHELL] {relpath}:{node.lineno}: "
@@ -98,7 +122,15 @@ def check_file(filepath: Path) -> list[str]:
 
 def main() -> int:
     errors: list[str] = []
-    for pyfile in sorted(SRC_DIR.rglob("*.py")):
+
+    if not SCAN_ROOT.exists() or not SCAN_ROOT.is_dir():
+        print(" QWED-Infra Boundary check FAILED")
+        print(f"  [CONFIG_ERROR] Scan root not found or not a directory: {SCAN_ROOT}")
+        return 1
+
+    for pyfile in sorted(SCAN_ROOT.rglob("*.py")):
+        if any(part in EXCLUDED_DIRS for part in pyfile.parts):
+            continue
         errors.extend(check_file(pyfile))
 
     if errors:

--- a/scripts/check_boundary.py
+++ b/scripts/check_boundary.py
@@ -41,10 +41,8 @@ def get_call_names(node: ast.Call) -> list[str]:
             current = current.value
         if isinstance(current, ast.Name):
             parts.append(current.id)
-        elif isinstance(current, ast.Call):
-            # Chained call like get_runner().run(...) — can't extract base name
-            pass
-        names.append(".".join(reversed(parts)))
+            names.append(".".join(reversed(parts)))
+        # Chained call like get_runner().run(...) → skip, not a bare call
     return names
 
 
@@ -88,12 +86,12 @@ def check_file(filepath: Path) -> list[str]:
                 )
 
             # Import-alias bypass: from subprocess import run; run("cmd")
-            if "." not in name and leaf in FORBIDDEN_LEAF_NAMES:
-                if leaf not in {"eval", "exec"}:
-                    errors.append(
-                        f"  [BARE_SHELL] {relpath}:{node.lineno}: "
-                        f"Disallowed bare call '{name}()' — possible import alias"
-                    )
+            # Skip if already caught by the dotted-name check above (prevents double-report)
+            elif "." not in name and name in FORBIDDEN_LEAF_NAMES:
+                errors.append(
+                    f"  [BARE_SHELL] {relpath}:{node.lineno}: "
+                    f"Disallowed bare call '{name}()' — possible import alias"
+                )
 
     return errors
 

--- a/scripts/check_boundary.py
+++ b/scripts/check_boundary.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Lightweight boundary check for QWED-Infra.
+
+Scans source files for forbidden patterns that introduce execution sinks.
+This is a release gate, not a replacement for proper security review.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC_DIR = REPO_ROOT / "qwed_infra"
+
+# Full call names that are forbidden (dotted names)
+FORBIDDEN_CALLS = {
+    "os.system",
+    "os.popen",
+    "subprocess.Popen",
+    "subprocess.call",
+    "subprocess.run",
+    "subprocess.check_call",
+    "subprocess.check_output",
+    "popen",
+}
+
+
+def get_call_names(node: ast.Call) -> list[str]:
+    names = []
+    if isinstance(node.func, ast.Name):
+        names.append(node.func.id)
+    elif isinstance(node.func, ast.Attribute):
+        parts = []
+        current = node.func
+        while isinstance(current, ast.Attribute):
+            parts.append(current.attr)
+            current = current.value
+        if isinstance(current, ast.Name):
+            parts.append(current.id)
+        elif isinstance(current, ast.Call):
+            return names
+        names.append(".".join(reversed(parts)))
+    return names
+
+
+def check_file(filepath: Path) -> list[str]:
+    errors = []
+    try:
+        tree = ast.parse(filepath.read_text(encoding="utf-8"))
+    except SyntaxError as exc:
+        errors.append(
+            f"  [PARSE_ERROR] {filepath.relative_to(REPO_ROOT)}:{exc.lineno}: "
+            "File could not be parsed; boundary check must fail closed"
+        )
+        return errors
+
+    relpath = filepath.relative_to(REPO_ROOT).as_posix()
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+
+        call_names = get_call_names(node)
+        if not call_names:
+            continue
+
+        for name in call_names:
+            leaf = name.split(".")[-1]
+
+            # bare eval/exec → always dangerous
+            if leaf in {"eval", "exec"}:
+                if "." not in name or name.startswith("builtins."):
+                    errors.append(
+                        f"  [BARE_EVAL] {relpath}:{node.lineno}: "
+                        f"Disallowed call '{name}()'"
+                    )
+
+            # os.system, subprocess.*, popen
+            if name in FORBIDDEN_CALLS:
+                errors.append(
+                    f"  [BARE_SHELL] {relpath}:{node.lineno}: "
+                    f"Disallowed call '{name}()'"
+                )
+
+    return errors
+
+
+def main() -> int:
+    errors: list[str] = []
+    for pyfile in sorted(SRC_DIR.rglob("*.py")):
+        errors.extend(check_file(pyfile))
+
+    if errors:
+        print(" QWED-Infra Boundary check FAILED")
+        for err in errors:
+            print(err)
+        return 1
+
+    print(" QWED-Infra Boundary check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_boundary.py
+++ b/scripts/check_boundary.py
@@ -91,7 +91,17 @@ def check_file(filepath: Path) -> list[str]:
 
         for name in call_names:
             # Resolve through import alias map to catch bypasses
+            # Handles: `from subprocess import run; run(...)` → run → subprocess.run
             resolved = alias_map.get(name, name)
+
+            # Also resolve module aliases in dotted names
+            # Handles: `import subprocess as sp; sp.run(...)` → sp → subprocess
+            if resolved == name and "." in name:
+                parts = name.split(".", 1)
+                resolved_module = alias_map.get(parts[0])
+                if resolved_module is not None:
+                    resolved = f"{resolved_module}.{parts[1]}"
+
             leaf = resolved.split(".")[-1]
 
             # bare eval/exec → always dangerous (resolved catches aliased imports)
@@ -107,14 +117,6 @@ def check_file(filepath: Path) -> list[str]:
                 errors.append(
                     f"  [BARE_SHELL] {relpath}:{node.lineno}: "
                     f"Disallowed call '{name}()'"
-                )
-
-            # Unresolved bare leaf name — possible import alias bypass
-            # Skip if already caught above (prevents double-report for e.g. popen)
-            elif "." not in name and name in FORBIDDEN_LEAF_NAMES:
-                errors.append(
-                    f"  [BARE_SHELL] {relpath}:{node.lineno}: "
-                    f"Disallowed bare call '{name}()' — possible import alias"
                 )
 
     return errors

--- a/tests/test_terraform_parser.py
+++ b/tests/test_terraform_parser.py
@@ -23,6 +23,7 @@ def test_parse_simple_infrastructure(mock_hcl2_load, parser, tmp_path):
     }
     
     resources = parser.parse_directory(str(tmp_path))
+    mock_hcl2_load.assert_called_once()
     
     # Verify Instances
     instances = resources["instances"]

--- a/tests/test_terraform_parser.py
+++ b/tests/test_terraform_parser.py
@@ -7,12 +7,22 @@ from unittest.mock import patch
 def parser():
     return TerraformParser()
 
-def test_parse_simple_infrastructure(parser):
-    # Locate fixture
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    fixtures_dir = os.path.join(current_dir, "fixtures")
+@patch('qwed_infra.parsers.terraform_parser.hcl2.load')
+def test_parse_simple_infrastructure(mock_hcl2_load, parser, tmp_path):
+    """Integration test: mock hcl2.load to return known HCL structure and verify parsing."""
+    # Create a dummy .tf file so the glob finds something
+    tf_file = tmp_path / "test.tf"
+    tf_file.write_text("")
     
-    resources = parser.parse_directory(fixtures_dir)
+    mock_hcl2_load.return_value = {
+        "resource": [
+            {"aws_instance": {"web": {"instance_type": "t3.micro", "count": 2}}},
+            {"aws_instance": {"gpu_node": {"instance_type": "p4d.24xlarge"}}},
+            {"aws_ebs_volume": {"data_vol": {"size": 40}}},
+        ]
+    }
+    
+    resources = parser.parse_directory(str(tmp_path))
     
     # Verify Instances
     instances = resources["instances"]


### PR DESCRIPTION
## Summary

Adopts the QWED ecosystem policy framework for qwed-infra, matching what was
already applied to qwed-verification and qwed-mcp. This PR adds the full set of
governance files that enforce the 12-principle QWED constitution across the
repository.

## Changes

| Commit | File | What |
|--------|------|------|
| 1 | `QWED_RULES.md` | 12-principle ecosystem constitution — direct copy (principles are repo-agnostic) |
| 2 | `.github/copilot-instructions.md` | AI assistant guardrails — minor tweak for IaC context |
| 3 | `.github/pull_request_template.md` | IaC-specific enforcement checklist (IAM, Network, Cost, subprocess) |
| 4 | `CONTRIBUTING.md` | Contributor guide with approved paths table for IaC |
| 5 | `.coderabbit.yaml` | Code review config with IaC-specific path instructions |
| 6 | `scripts/check_boundary.py` | Simplified CI gate — scan subprocess/os.system/shell=True |
| 7 | `.github/workflows/tests.yml` | Add boundary check step after setup-python |

## Why This Is Needed

The vulnerability family sweep confirmed:

- **Security posture: PASS** — No eval/parse_expr/sympify sinks exist in infra
- **Policy posture: MISSING** — None of the QWED ecosystem governance files exist yet

Policy import is the gap. Code risk is low.

## Verification

- [ ] QWED_RULES.md matches the canonical 12 principles used in verification/mcp repos
- [ ] Copilot instructions aligned with ecosystem standard
- [ ] PR template covers IaC-specific enforcement (IAM, Network, Cost)
- [ ] Boundary check runs on CI without false positives

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added repository enforcement rules with a review checklist and contributor guidelines.
  * Updated Copilot instructions and the pull request template to require explicit compliance with the rules.
  * Added detailed contribution guidance emphasizing deterministic, fail-closed verification.

* **Chores**
  * Added a CI boundary check gate that fails early on unsafe Python patterns before dependencies and tests run.
  * Updated automated review configuration to enforce the rules.
  * Made SonarCloud scanning conditional on token availability.

* **Tests**
  * Refreshed the Terraform parser test to use isolated, temporary-file-based inputs with mocked HCL loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->