### PR TITLE
fix: parser fail-closed + IAM policy extraction (close #8, close #9)

### DIFF
--- a/demo/verify_demo.py
+++ b/demo/verify_demo.py
@@ -15,7 +15,7 @@ def run_demo():
     try:
         resources = parser.parse_directory(demo_dir)
     except ParseError as e:
-        print(f"❌ DEMO FAILED: Terraform parse error(s):")
+        print("❌ DEMO FAILED: Terraform parse error(s):")
         for err in e.errors:
             print(f"   - {err}")
         sys.exit(1)

--- a/demo/verify_demo.py
+++ b/demo/verify_demo.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from qwed_infra import IamGuard, NetworkGuard, CostGuard, TerraformParser
+from qwed_infra.parsers.terraform_parser import ParseError
 
 def run_demo():
     print("🚀 Starting QWED-Infra Verification Demo")
@@ -11,7 +12,14 @@ def run_demo():
     demo_dir = os.path.dirname(os.path.abspath(__file__))
     print(f"📂 Parsing Terraform in: {demo_dir}")
     
-    resources = parser.parse_directory(demo_dir)
+    try:
+        resources = parser.parse_directory(demo_dir)
+    except ParseError as e:
+        print(f"❌ DEMO FAILED: Terraform parse error(s):")
+        for err in e.errors:
+            print(f"   - {err}")
+        sys.exit(1)
+
     print(f"   Found {len(resources['instances'])} instances, {len(resources['policies'])} policies.")
     
     guards_failed = 0

--- a/qwed_infra/parsers/terraform_parser.py
+++ b/qwed_infra/parsers/terraform_parser.py
@@ -92,7 +92,7 @@ class TerraformParser:
         return qwed_resources
 
     def _normalize_resource(
-        self, res_type: str, res_name: str, config: Dict[str, Any]
+        self, res_type: str, res_name: str, config: Any
     ) -> Optional[Dict[str, Any]]:
         """
         Maps generic Terraform resource types to QWED schema.
@@ -102,6 +102,14 @@ class TerraformParser:
                 IAM policy body cannot be extracted). The caller catches this
                 and converts it into a ParseError entry.
         """
+        # hcl2 may wrap the entire config dict in a single-element list
+        if isinstance(config, list) and len(config) == 1:
+            config = config[0]
+        if not isinstance(config, dict):
+            raise ValueError(
+                f"{res_type}.{res_name}: config is {type(config).__name__}, "
+                f"not a dict — cannot normalize."
+            )
         config = self._unwrap_hcl2_values(config)
 
         # --- Compute ---

--- a/qwed_infra/parsers/terraform_parser.py
+++ b/qwed_infra/parsers/terraform_parser.py
@@ -114,7 +114,7 @@ class TerraformParser:
         """
         result: Dict[str, Any] = {}
         for key, val in data.items():
-            clean_key = key.strip('"')
+            clean_key = key.removeprefix('"').removesuffix('"')
             result[clean_key] = TerraformParser._normalize_hcl2_value(val)
         return result
 
@@ -126,7 +126,7 @@ class TerraformParser:
             for k, v in val.items():
                 if k == "__is_block__":
                     continue
-                cleaned[k.strip('"')] = TerraformParser._normalize_hcl2_value(v)
+                cleaned[k.removeprefix('"').removesuffix('"')] = TerraformParser._normalize_hcl2_value(v)
             return cleaned
         if isinstance(val, list):
             return [TerraformParser._normalize_hcl2_value(v) for v in val]

--- a/qwed_infra/parsers/terraform_parser.py
+++ b/qwed_infra/parsers/terraform_parser.py
@@ -1,6 +1,5 @@
 import ast
 import json
-import re
 import hcl2
 from typing import Dict, Any, Optional, List
 from pathlib import Path
@@ -254,22 +253,64 @@ class TerraformParser:
     def _reject_unresolved_interpolation(res_name: str, value: Any) -> None:
         """Recursively reject Terraform interpolation syntax (${...}) in values.
 
-        Unresolved interpolation (e.g. ``${var.action}``) means the policy
-        cannot be deterministically verified — the actual value is unknown at
-        parse time. Fail-closed per QWED_RULES Principle 2.
+        Unresolved Terraform interpolation (e.g. ``${var.action}``) means the
+        policy cannot be deterministically verified — the actual value is
+        unknown at parse time. Fail-closed per QWED_RULES Principle 2.
+
+        However, AWS IAM policy variables (e.g. ``${aws:username}``,
+        ``${saml:sub}``) are valid runtime-resolved variables that AWS
+        evaluates at request time — these are NOT Terraform interpolation
+        and must be allowed through.
+
+        Terraform interpolation prefixes: ``var.``, ``local.``, ``module.``,
+        ``data.``, ``aws_*.``, ``file()``, ``jsonencode()`` etc.
+        AWS policy variables: ``${aws:*}``, ``${saml:*}``, ``${cognito:*}``,
+        ``${iam:*}``, ``${redshift:*}``, ``${sourceIp}``, ``${epochTime}``,
+        ``${requestRegion}``, etc.
         """
         if isinstance(value, str) and "${" in value:
-            raise ValueError(
-                f"aws_iam_policy '{res_name}': policy contains unresolved "
-                f"Terraform interpolation '{value}' — cannot extract "
-                f"deterministically. Resolve variables before parsing."
-            )
+            TerraformParser._check_interpolation_value(res_name, value)
         if isinstance(value, dict):
             for nested in value.values():
                 TerraformParser._reject_unresolved_interpolation(res_name, nested)
         elif isinstance(value, list):
             for nested in value:
                 TerraformParser._reject_unresolved_interpolation(res_name, nested)
+
+    @staticmethod
+    def _check_interpolation_value(res_name: str, value: str) -> None:
+        """Check a single string for unresolved Terraform interpolation.
+
+        AWS policy variables are allowed. Terraform interpolation is rejected.
+        """
+        idx = 0
+        while True:
+            start = value.find("${", idx)
+            if start == -1:
+                return
+            end = value.find("}", start)
+            if end == -1:
+                return
+            inner = value[start + 2:end].strip()
+            # AWS policy variables: ${aws:username}, ${saml:sub}, etc.
+            # These contain a colon and are NOT Terraform interpolation.
+            if ":" in inner:
+                idx = end + 1
+                continue
+            # Terraform interpolation: ${var.name}, ${local.x}, ${module.y}
+            if inner.startswith(("var.", "local.", "module.", "data.")):
+                raise ValueError(
+                    f"aws_iam_policy '{res_name}': policy contains unresolved "
+                    f"Terraform interpolation '{value}' — cannot extract "
+                    f"deterministically. Resolve variables before parsing."
+                )
+            # Unknown ${...} without a colon — fail-closed
+            raise ValueError(
+                f"aws_iam_policy '{res_name}': policy contains unresolved "
+                f"interpolation '${{{inner}}}' — cannot verify deterministically. "
+                f"If this is an AWS policy variable, it must use a colon "
+                f"(e.g. ${{aws:username}})."
+            )
 
     @staticmethod
     def _extract_policy_document(
@@ -402,7 +443,8 @@ class TerraformParser:
         - ``=`` outside quotes (after identifiers) → ``:``
 
         Values inside quoted strings (e.g. ``"Team=backend"``) are
-        left untouched.
+        left untouched. Escaped quotes (``\\"``) inside strings are
+        handled correctly.
 
         (Sentry HIGH — regex-based replacement corrupted values
         containing ``=`` inside quoted strings.)
@@ -413,37 +455,48 @@ class TerraformParser:
         while i < len(content):
             ch = content[i]
 
-            if ch == '"':
-                in_string = not in_string
-                result.append(ch)
-                i += 1
-                continue
-
             if in_string:
                 result.append(ch)
+                if ch == '\\' and i + 1 < len(content):
+                    result.append(content[i + 1])
+                    i += 2
+                    continue
+                if ch == '"':
+                    in_string = False
                 i += 1
                 continue
 
-            # Outside a string: check for unquoted identifier followed by =
-            if ch.isalpha() or ch == '_':
-                j = i
-                while j < len(content) and (
-                    content[j].isalnum() or content[j] == '_'
-                ):
-                    j += 1
-                # Look ahead for = (possibly with whitespace)
-                k = j
-                while k < len(content) and content[k] in (' ', '\t'):
-                    k += 1
-                if k < len(content) and content[k] == '=':
-                    identifier = content[i:j]
-                    result.append('"')
-                    result.append(identifier)
-                    result.append('":')
-                    i = k + 1
-                    continue
+            if ch == '"':
+                in_string = True
+                result.append(ch)
+                i += 1
+                continue
 
-            result.append(ch)
-            i += 1
-
+            i = TerraformParser._try_identifier_equals(result, content, i)
         return ''.join(result)
+
+    @staticmethod
+    def _try_identifier_equals(
+        result: List[str], content: str, i: int
+    ) -> int:
+        """Try to match an unquoted identifier followed by = at position i.
+
+        If matched, appends ``"identifier":`` to result and returns the
+        index after the ``=``. Otherwise, appends the single character and
+        returns i+1.
+        """
+        ch = content[i]
+        if ch.isalpha() or ch == '_':
+            j = i
+            while j < len(content) and (content[j].isalnum() or content[j] == '_'):
+                j += 1
+            k = j
+            while k < len(content) and content[k] in (' ', '\t'):
+                k += 1
+            if k < len(content) and content[k] == '=':
+                result.append('"')
+                result.append(content[i:j])
+                result.append('":')
+                return k + 1
+        result.append(ch)
+        return i + 1

--- a/qwed_infra/parsers/terraform_parser.py
+++ b/qwed_infra/parsers/terraform_parser.py
@@ -260,16 +260,15 @@ class TerraformParser:
         policy cannot be deterministically verified — the actual value is
         unknown at parse time. Fail-closed per QWED_RULES Principle 2.
 
-        However, AWS IAM policy variables (e.g. ``${aws:username}``,
-        ``${saml:sub}``) are valid runtime-resolved variables that AWS
-        evaluates at request time — these are NOT Terraform interpolation
-        and must be allowed through.
+        AWS IAM policy variables (e.g. ``${aws:username}``, ``${saml:sub}``)
+        are valid runtime-resolved variables that AWS evaluates at request
+        time — these use a colon and are NOT Terraform interpolation, so
+        they are allowed through.
 
         Terraform interpolation prefixes: ``var.``, ``local.``, ``module.``,
-        ``data.``, ``aws_*.``, ``file()``, ``jsonencode()`` etc.
+        ``data.``, ``file()``, ``jsonencode()`` etc.
         AWS policy variables: ``${aws:*}``, ``${saml:*}``, ``${cognito:*}``,
-        ``${iam:*}``, ``${redshift:*}``, ``${sourceIp}``, ``${epochTime}``,
-        ``${requestRegion}``, etc.
+        ``${iam:*}``, ``${redshift:*}``, etc.
         """
         if isinstance(value, str) and "${" in value:
             TerraformParser._check_interpolation_value(res_name, value)

--- a/qwed_infra/parsers/terraform_parser.py
+++ b/qwed_infra/parsers/terraform_parser.py
@@ -61,13 +61,9 @@ class TerraformParser:
                 errors.append(f"Failed to parse {tf_file.name}: {e}")
                 continue
 
-        if errors:
-            raise ParseError(errors)
-
-        # 2. Normalize to QWED Internal Schema — continue even if HCL parse
-        # errors occurred, so normalization errors are aggregated together.
-        # If HCL errors exist, normalization runs on the partial HCL data
-        # (which may be empty), but the final ParseError will still be raised.
+        # 2. Normalize to QWED Internal Schema — run normalization even if
+        # HCL parse errors occurred, so all errors (parse + normalization)
+        # are aggregated into a single ParseError.
         qwed_resources: Dict[str, list] = {
             "instances": [],
             "policies": [],

--- a/qwed_infra/parsers/terraform_parser.py
+++ b/qwed_infra/parsers/terraform_parser.py
@@ -1,3 +1,4 @@
+import ast
 import json
 import re
 import hcl2
@@ -60,7 +61,10 @@ class TerraformParser:
         if errors:
             raise ParseError(errors)
 
-        # 2. Normalize to QWED Internal Schema
+        # 2. Normalize to QWED Internal Schema — continue even if HCL parse
+        # errors occurred, so normalization errors are aggregated together.
+        # If HCL errors exist, normalization runs on the partial HCL data
+        # (which may be empty), but the final ParseError will still be raised.
         qwed_resources: Dict[str, list] = {
             "instances": [],
             "policies": [],
@@ -177,11 +181,18 @@ class TerraformParser:
     def _validate_statements(
         res_name: str, doc: Dict[str, Any]
     ) -> List[Dict[str, Any]]:
-        """Validate that a parsed policy document contains a Statement list.
+        """Validate that a parsed policy document contains a Statement list
+        where each entry is a dict.
+
+        Also recursively rejects unresolved Terraform interpolation (${...})
+        in any string value within the policy document.
 
         Raises:
-            ValueError: if 'Statement' is missing or not a list.
+            ValueError: if 'Statement' is missing, not a list, contains
+                non-dict entries, or contains unresolved interpolation.
         """
+        TerraformParser._reject_unresolved_interpolation(res_name, doc)
+
         if "Statement" not in doc:
             raise ValueError(
                 f"aws_iam_policy '{res_name}': policy document has no "
@@ -193,7 +204,35 @@ class TerraformParser:
                 f"aws_iam_policy '{res_name}': 'Statement' is not a list "
                 f"— cannot extract."
             )
+        for index, statement in enumerate(statements):
+            if not isinstance(statement, dict):
+                raise ValueError(
+                    f"aws_iam_policy '{res_name}': Statement[{index}] is "
+                    f"{type(statement).__name__}, not a dict — cannot extract."
+                )
+            TerraformParser._reject_unresolved_interpolation(res_name, statement)
         return statements
+
+    @staticmethod
+    def _reject_unresolved_interpolation(res_name: str, value: Any) -> None:
+        """Recursively reject Terraform interpolation syntax (${...}) in values.
+
+        Unresolved interpolation (e.g. ``${var.action}``) means the policy
+        cannot be deterministically verified — the actual value is unknown at
+        parse time. Fail-closed per QWED_RULES Principle 2.
+        """
+        if isinstance(value, str) and "${" in value:
+            raise ValueError(
+                f"aws_iam_policy '{res_name}': policy contains unresolved "
+                f"Terraform interpolation '{value}' — cannot extract "
+                f"deterministically. Resolve variables before parsing."
+            )
+        if isinstance(value, dict):
+            for nested in value.values():
+                TerraformParser._reject_unresolved_interpolation(res_name, nested)
+        elif isinstance(value, list):
+            for nested in value:
+                TerraformParser._reject_unresolved_interpolation(res_name, nested)
 
     @staticmethod
     def _extract_policy_document(
@@ -272,21 +311,22 @@ class TerraformParser:
     ) -> Dict[str, Any]:
         """Parse the inner content of a ${jsonencode(...)} interpolation.
 
-        hcl2 converts HCL map syntax to JSON-like key-value pairs with escaped
-        quotes (e.g. ``{\"Version\": \"2012-10-17\", ...}``). This is already
-        valid JSON after extraction, so we parse it directly.
+        hcl2 converts HCL map syntax to Python literal syntax with single
+        quotes (e.g. ``{'Version': '2012-10-17', ...}``) — NOT valid JSON.
+        We use ``ast.literal_eval`` which safely evaluates Python literals
+        (dict, list, str, num, bool, None) without executing arbitrary code.
 
         Raises:
             ValueError: if the content cannot be parsed as a dict.
         """
         content = content.strip()
         try:
-            parsed = json.loads(content)
-        except json.JSONDecodeError as exc:
+            parsed = ast.literal_eval(content)
+        except (ValueError, SyntaxError) as exc:
             raise ValueError(
                 f"aws_iam_policy '{res_name}': jsonencode content is not "
-                f"valid JSON — {exc}. This may indicate unsupported HCL "
-                f"constructs inside the jsonencode call."
+                f"valid Python literal — {exc}. This may indicate unsupported "
+                f"HCL constructs inside the jsonencode call."
             ) from exc
 
         if not isinstance(parsed, dict):

--- a/qwed_infra/parsers/terraform_parser.py
+++ b/qwed_infra/parsers/terraform_parser.py
@@ -293,32 +293,38 @@ class TerraformParser:
                 return
             inner = value[start + 2:end].strip()
             # AWS policy variables: ${aws:username}, ${saml:sub}, etc.
-            # These contain a colon AND have no nested braces.
-            if ":" in inner and "{" not in inner:
+            # Strictly whitelist known AWS namespaces to avoid false-negatives
+            # (e.g. Terraform for-expressions with colons bypass colon check).
+            # (Greptile P1 — for-expression bypass fix)
+            if TerraformParser._is_aws_policy_variable(inner):
                 idx = end + 1
                 continue
-            # Terraform interpolation: ${var.name}, ${local.x}, ${module.y}
-            if inner.startswith(("var.", "local.", "module.", "data.")):
-                raise ValueError(
-                    f"aws_iam_policy '{res_name}': policy contains unresolved "
-                    f"Terraform interpolation '{value}' — cannot extract "
-                    f"deterministically. Resolve variables before parsing."
-                )
-            # Contains nested braces (e.g. merge({...}, ...)) — Terraform
-            # function call, not an AWS policy variable. Fail-closed.
-            if "{" in inner or "(" in inner:
-                raise ValueError(
-                    f"aws_iam_policy '{res_name}': policy contains unresolved "
-                    f"Terraform interpolation '{value}' — contains function "
-                    f"calls or nested maps. Resolve before parsing."
-                )
-            # Unknown ${...} without a colon — fail-closed
+            # Everything else is unresolved interpolation — fail-closed
             raise ValueError(
                 f"aws_iam_policy '{res_name}': policy contains unresolved "
-                f"interpolation '${{{inner}}}' — cannot verify deterministically. "
-                f"If this is an AWS policy variable, it must use a colon "
-                f"(e.g. ${{aws:username}})."
+                f"interpolation '{value}' — cannot verify deterministically. "
+                f"Resolve Terraform variables before parsing, or use AWS "
+                f"policy variables with a namespace (e.g. ${{aws:username}})."
             )
+
+    @staticmethod
+    def _is_aws_policy_variable(inner: str) -> bool:
+        """Check if an ${...} value is a known AWS IAM policy variable.
+
+        AWS policy variables use a namespace prefix with a colon:
+        ``aws:username``, ``saml:sub``, ``cognito:username``, etc.
+
+        This whitelist prevents Terraform expressions that happen to contain
+        colons (e.g. ``[for s in var.actions : s]``) from bypassing the
+        interpolation guard. (Greptile P1)
+        """
+        AWS_PREFIXES = (
+            "aws:", "saml:", "cognito:", "iam:", "redshift:",
+            "s3:", "sts:", "ec2:", "waf:", "grafana:",
+        )
+        if "{" in inner or "[" in inner or "(" in inner:
+            return False
+        return inner.startswith(AWS_PREFIXES)
 
     @staticmethod
     def _find_matching_brace(value: str, start: int) -> int:

--- a/qwed_infra/parsers/terraform_parser.py
+++ b/qwed_infra/parsers/terraform_parser.py
@@ -515,17 +515,26 @@ class TerraformParser:
 
             if ch in ('"', "'"):
                 quote = ch
-                result.append(ch)
+                # Convert single quotes to double quotes for valid JSON output
+                result.append('"')
                 i += 1
                 while i < len(content):
-                    result.append(content[i])
                     if content[i] == '\\' and i + 1 < len(content):
+                        # Preserve escape sequences
+                        result.append(content[i])
                         result.append(content[i + 1])
                         i += 2
                         continue
                     if content[i] == quote:
+                        result.append('"')
                         i += 1
                         break
+                    # Escape any unescaped double quotes inside the value
+                    if content[i] == '"' and quote == "'":
+                        result.append('\\"')
+                        i += 1
+                        continue
+                    result.append(content[i])
                     i += 1
                 continue
 

--- a/qwed_infra/parsers/terraform_parser.py
+++ b/qwed_infra/parsers/terraform_parser.py
@@ -15,7 +15,10 @@ class ParseError(Exception):
 
     def __init__(self, errors: List[str]):
         self.errors = errors
-        super().__init__(f"Parse failed with {len(errors)} error(s):\n" + "\n".join(f"  - {e}" for e in errors))
+        super().__init__(
+            f"Parse failed with {len(errors)} error(s):\n"
+            + "\n".join(f"  - {e}" for e in errors)
+        )
 
 
 class TerraformParser:
@@ -42,14 +45,14 @@ class TerraformParser:
 
         # 1. Read and merge generic HCL structure
         for tf_file in sorted(path.glob("*.tf")):
-            with open(tf_file, 'r') as f:
+            with open(tf_file, "r") as f:
                 try:
                     data = hcl2.load(f)
                     for key, val in data.items():
                         if key not in combined_hcl:
                             combined_hcl[key] = []
                         combined_hcl[key].extend(val)
-                except Exception as e:
+                except Exception as e:  # noqa: BLE001
                     errors.append(f"Failed to parse {tf_file.name}: {e}")
                     continue
 
@@ -57,12 +60,12 @@ class TerraformParser:
             raise ParseError(errors)
 
         # 2. Normalize to QWED Internal Schema
-        qwed_resources = {
+        qwed_resources: Dict[str, list] = {
             "instances": [],
             "policies": [],
             "subnets": [],
             "security_groups": [],
-            "volumes": []
+            "volumes": [],
         }
 
         resources = combined_hcl.get("resource", [])
@@ -71,21 +74,25 @@ class TerraformParser:
             for res_type, res_dict in resource_block.items():
                 for res_name, config in res_dict.items():
                     try:
-                        normalized = self._normalize_resource(res_type, res_name, config)
+                        normalized = self._normalize_resource(
+                            res_type, res_name, config
+                        )
                         if normalized:
                             cat = normalized["category"]
                             qwed_resources[cat].append(normalized["data"])
-                    except ParseError:
-                        raise
-                    except Exception as e:
-                        errors.append(f"Failed to normalize {res_type}.{res_name}: {e}")
+                    except Exception as e:  # noqa: BLE001
+                        errors.append(
+                            f"Failed to normalize {res_type}.{res_name}: {e}"
+                        )
 
         if errors:
             raise ParseError(errors)
 
         return qwed_resources
 
-    def _normalize_resource(self, res_type: str, res_name: str, config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    def _normalize_resource(
+        self, res_type: str, res_name: str, config: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
         """
         Maps generic Terraform resource types to QWED schema.
 
@@ -94,6 +101,8 @@ class TerraformParser:
                 IAM policy body cannot be extracted). The caller catches this
                 and converts it into a ParseError entry.
         """
+        config = self._unwrap_hcl2_values(config)
+
         # --- Compute ---
         if res_type == "aws_instance":
             instance_type = config.get("instance_type")
@@ -107,22 +116,23 @@ class TerraformParser:
                 "data": {
                     "id": res_name,
                     "instance_type": instance_type,
-                    "count": config.get("count", 1)
-                }
+                    "count": config.get("count", 1),
+                },
             }
 
         # --- IAM ---
         if res_type == "aws_iam_policy":
-            policy_json = config.get("policy")
-            statements = self._extract_policy_statements(res_name, policy_json)
-
+            policy_body = config.get("policy")
+            policy_doc = self._extract_policy_document(res_name, policy_body)
             return {
                 "category": "policies",
                 "data": {
                     "id": res_name,
-                    "Version": "2012-10-17",
-                    "Statement": statements
-                }
+                    "Version": policy_doc.get("Version", "2012-10-17"),
+                    "Statement": self._validate_statements(
+                        res_name, policy_doc
+                    ),
+                },
             }
 
         # --- Storage ---
@@ -131,21 +141,63 @@ class TerraformParser:
                 "category": "volumes",
                 "data": {
                     "id": res_name,
-                    "size_gb": config.get("size", 10)
-                }
+                    "size_gb": config.get("size", 10),
+                },
             }
 
         return None
 
     @staticmethod
-    def _extract_policy_statements(res_name: str, policy_body: Any) -> List[Dict[str, Any]]:
+    def _unwrap_hcl2_values(config: Dict[str, Any]) -> Dict[str, Any]:
+        """Unwrap hcl2 list-wrapped attribute values.
+
+        python-hcl2 wraps all attribute values in single-element lists
+        (e.g. ``"t3.micro"`` becomes ``["t3.micro"]``). This unwraps
+        single-element lists to their scalar value so downstream code
+        can type-check normally.
         """
-        Deterministically extract IAM policy statements from a Terraform
+        unwrapped: Dict[str, Any] = {}
+        for key, val in config.items():
+            if isinstance(val, list) and len(val) == 1:
+                unwrapped[key] = val[0]
+            else:
+                unwrapped[key] = val
+        return unwrapped
+
+    @staticmethod
+    def _validate_statements(
+        res_name: str, doc: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
+        """Validate that a parsed policy document contains a Statement list.
+
+        Raises:
+            ValueError: if 'Statement' is missing or not a list.
+        """
+        if "Statement" not in doc:
+            raise ValueError(
+                f"aws_iam_policy '{res_name}': policy document has no "
+                f"'Statement' key — cannot extract."
+            )
+        statements = doc["Statement"]
+        if not isinstance(statements, list):
+            raise ValueError(
+                f"aws_iam_policy '{res_name}': 'Statement' is not a list "
+                f"— cannot extract."
+            )
+        return statements
+
+    @staticmethod
+    def _extract_policy_document(
+        res_name: str, policy_body: Any
+    ) -> Dict[str, Any]:
+        """
+        Deterministically extract the IAM policy document from a Terraform
         aws_iam_policy resource.
 
-        hcl2 parses jsonencode({...}) as a dict directly. Heredoc and raw
-        string policies come through as strings. Variable interpolation
-        (file(), var.x) cannot be resolved and must fail-closed.
+        hcl2 may return the policy as a dict (jsonencode parsed), a JSON
+        string (heredoc), or a ``${jsonencode(...)}`` interpolation string.
+        Variable interpolation (file(), var.x) cannot be resolved and must
+        fail-closed.
 
         Raises:
             ValueError: if the policy body cannot be faithfully extracted.
@@ -158,18 +210,7 @@ class TerraformParser:
 
         # Case 1: hcl2 parsed jsonencode(...) as a dict
         if isinstance(policy_body, dict):
-            if "Statement" not in policy_body:
-                raise ValueError(
-                    f"aws_iam_policy '{res_name}': jsonencode policy body has "
-                    f"no 'Statement' key — cannot extract."
-                )
-            statements = policy_body["Statement"]
-            if not isinstance(statements, list):
-                raise ValueError(
-                    f"aws_iam_policy '{res_name}': jsonencode policy 'Statement' "
-                    f"is not a list — cannot extract."
-                )
-            return statements
+            return policy_body
 
         # Case 2: heredoc or raw JSON string
         if isinstance(policy_body, str):
@@ -193,20 +234,14 @@ class TerraformParser:
                     f"like file() or var.x) — {exc}. Refusing to emit a placeholder."
                 ) from exc
 
-            if "Statement" not in parsed:
+            if not isinstance(parsed, dict):
                 raise ValueError(
-                    f"aws_iam_policy '{res_name}': parsed JSON policy has no "
-                    f"'Statement' key — cannot extract."
+                    f"aws_iam_policy '{res_name}': parsed JSON is not a dict "
+                    f"— cannot extract policy document."
                 )
-            statements = parsed["Statement"]
-            if not isinstance(statements, list):
-                raise ValueError(
-                    f"aws_iam_policy '{res_name}': parsed JSON 'Statement' "
-                    f"is not a list — cannot extract."
-                )
-            return statements
+            return parsed
 
-        # Case 3: unsupported type (e.g. list, int, custom object)
+        # Case 3: unsupported type
         raise ValueError(
             f"aws_iam_policy '{res_name}': policy body is of type "
             f"{type(policy_body).__name__} — cannot extract. Supported forms: "

--- a/qwed_infra/parsers/terraform_parser.py
+++ b/qwed_infra/parsers/terraform_parser.py
@@ -1,4 +1,5 @@
 import json
+import re
 import hcl2
 from typing import Dict, Any, Optional, List
 from pathlib import Path
@@ -45,16 +46,16 @@ class TerraformParser:
 
         # 1. Read and merge generic HCL structure
         for tf_file in sorted(path.glob("*.tf")):
-            with open(tf_file, "r") as f:
-                try:
+            try:
+                with open(tf_file, "r") as f:
                     data = hcl2.load(f)
                     for key, val in data.items():
                         if key not in combined_hcl:
                             combined_hcl[key] = []
                         combined_hcl[key].extend(val)
-                except Exception as e:  # noqa: BLE001
-                    errors.append(f"Failed to parse {tf_file.name}: {e}")
-                    continue
+            except Exception as e:  # noqa: BLE001
+                errors.append(f"Failed to parse {tf_file.name}: {e}")
+                continue
 
         if errors:
             raise ParseError(errors)
@@ -212,7 +213,7 @@ class TerraformParser:
         if isinstance(policy_body, dict):
             return policy_body
 
-        # Case 2: heredoc or raw JSON string
+        # Case 2: heredoc, raw JSON string, or ${jsonencode(...)} interpolation
         if isinstance(policy_body, str):
             stripped = policy_body.strip()
             if not stripped:
@@ -220,6 +221,15 @@ class TerraformParser:
                     f"aws_iam_policy '{res_name}': policy body is an empty "
                     f"string — cannot extract statements."
                 )
+
+            # hcl2 returns jsonencode(...) as "${jsonencode({...})}" — extract
+            # the inner JSON-like content and convert HCL map syntax to JSON
+            if stripped.startswith("${jsonencode(") and stripped.endswith(")}"):
+                inner = stripped[len("${jsonencode("):-len(")}")]
+                parsed = TerraformParser._parse_hcl_jsonencode_content(
+                    res_name, inner
+                )
+                return parsed
 
             # hcl2 sometimes wraps strings in ${...} interpolation syntax
             if stripped.startswith("${") and stripped.endswith("}"):
@@ -247,3 +257,33 @@ class TerraformParser:
             f"{type(policy_body).__name__} — cannot extract. Supported forms: "
             f"jsonencode dict, JSON string, or heredoc."
         )
+
+    @staticmethod
+    def _parse_hcl_jsonencode_content(
+        res_name: str, content: str
+    ) -> Dict[str, Any]:
+        """Parse the inner content of a ${jsonencode(...)} interpolation.
+
+        hcl2 converts HCL map syntax to JSON-like key-value pairs with escaped
+        quotes (e.g. ``{\"Version\": \"2012-10-17\", ...}``). This is already
+        valid JSON after extraction, so we parse it directly.
+
+        Raises:
+            ValueError: if the content cannot be parsed as a dict.
+        """
+        content = content.strip()
+        try:
+            parsed = json.loads(content)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"aws_iam_policy '{res_name}': jsonencode content is not "
+                f"valid JSON — {exc}. This may indicate unsupported HCL "
+                f"constructs inside the jsonencode call."
+            ) from exc
+
+        if not isinstance(parsed, dict):
+            raise ValueError(
+                f"aws_iam_policy '{res_name}': jsonencode content parsed to "
+                f"{type(parsed).__name__}, not a dict — cannot extract."
+            )
+        return parsed

--- a/qwed_infra/parsers/terraform_parser.py
+++ b/qwed_infra/parsers/terraform_parser.py
@@ -348,9 +348,12 @@ class TerraformParser:
                 )
 
             # hcl2 returns jsonencode(...) as "${jsonencode({...})}" — extract
-            # the inner JSON-like content and convert HCL map syntax to JSON
-            if stripped.startswith("${jsonencode(") and stripped.endswith(")}"):
-                inner = stripped[len("${jsonencode("):-len(")}")]
+            # the inner content by tracking parenthesis depth (not string
+            # slicing, which breaks on ) inside string values)
+            if stripped.startswith("${jsonencode("):
+                inner = TerraformParser._extract_jsonencode_inner(
+                    res_name, stripped
+                )
                 parsed = TerraformParser._parse_hcl_jsonencode_content(
                     res_name, inner
                 )
@@ -381,6 +384,51 @@ class TerraformParser:
             f"aws_iam_policy '{res_name}': policy body is of type "
             f"{type(policy_body).__name__} — cannot extract. Supported forms: "
             f"jsonencode dict, JSON string, or heredoc."
+        )
+
+    @staticmethod
+    def _extract_jsonencode_inner(res_name: str, raw: str) -> str:
+        """Extract the inner content of ``${jsonencode(...)}`` by tracking
+        parenthesis depth.
+
+        Simple string slicing (``raw[:-2]``) breaks when a string value
+        inside the jsonencode contains ``)`` — e.g. an ARN like
+        ``"arn:aws:s3:::bucket)"``. This method walks the content
+        character by character, tracking quote state and parenthesis
+        depth, and extracts the content between the opening ``(`` and
+        its matching ``)``.
+
+        (Sentry MEDIUM — fixed-length suffix slicing was brittle.)
+        """
+        prefix = "${jsonencode("
+        start = len(prefix)
+        depth = 1
+        in_string = False
+        i = start
+        while i < len(raw):
+            ch = raw[i]
+            if in_string:
+                if ch == '\\' and i + 1 < len(raw):
+                    i += 2
+                    continue
+                if ch == '"':
+                    in_string = False
+                i += 1
+                continue
+            if ch == '"':
+                in_string = True
+                i += 1
+                continue
+            if ch == '(':
+                depth += 1
+            elif ch == ')':
+                depth -= 1
+                if depth == 0:
+                    return raw[start:i]
+            i += 1
+        raise ValueError(
+            f"aws_iam_policy '{res_name}': unterminated jsonencode() — "
+            f"no matching closing parenthesis found."
         )
 
     @staticmethod

--- a/qwed_infra/parsers/terraform_parser.py
+++ b/qwed_infra/parsers/terraform_parser.py
@@ -1,6 +1,5 @@
 import ast
 import json
-import re
 import hcl2
 from typing import Dict, Any, Optional, List
 from pathlib import Path

--- a/qwed_infra/parsers/terraform_parser.py
+++ b/qwed_infra/parsers/terraform_parser.py
@@ -129,7 +129,7 @@ class TerraformParser:
         if isinstance(val, list):
             return [TerraformParser._normalize_hcl2_value(v) for v in val]
         if isinstance(val, str):
-            return val.strip('"')
+            return val.removeprefix('"').removesuffix('"')
         return val
 
     def _normalize_resource(
@@ -365,10 +365,9 @@ class TerraformParser:
 
         # Convert HCL map syntax to JSON:
         # {Version = "x"} → {"Version": "x"}
-        # Match unquoted word keys followed by = (not inside string values)
-        json_content = re.sub(
-            r'(\b[A-Za-z_]\w*)\s*=', r'"\1":', content
-        )
+        # Only replace = outside of quoted strings to avoid corrupting
+        # values like "Team=backend" (Sentry HIGH)
+        json_content = TerraformParser._hcl_map_to_json(content)
 
         try:
             parsed = json.loads(json_content)
@@ -389,3 +388,62 @@ class TerraformParser:
                 f"{type(parsed).__name__}, not a dict — cannot extract."
             )
         return parsed
+
+    @staticmethod
+    def _hcl_map_to_json(content: str) -> str:
+        """Convert HCL map syntax to JSON outside of quoted strings.
+
+        HCL uses ``=`` for key-value pairs and may have unquoted keys:
+        ``{Version = "x", Action = "*"}``
+
+        This function walks the content character by character, tracking
+        whether we're inside a quoted string, and only transforms:
+        - Unquoted identifiers followed by ``=`` → ``"identifier":``
+        - ``=`` outside quotes (after identifiers) → ``:``
+
+        Values inside quoted strings (e.g. ``"Team=backend"``) are
+        left untouched.
+
+        (Sentry HIGH — regex-based replacement corrupted values
+        containing ``=`` inside quoted strings.)
+        """
+        result: List[str] = []
+        i = 0
+        in_string = False
+        while i < len(content):
+            ch = content[i]
+
+            if ch == '"':
+                in_string = not in_string
+                result.append(ch)
+                i += 1
+                continue
+
+            if in_string:
+                result.append(ch)
+                i += 1
+                continue
+
+            # Outside a string: check for unquoted identifier followed by =
+            if ch.isalpha() or ch == '_':
+                j = i
+                while j < len(content) and (
+                    content[j].isalnum() or content[j] == '_'
+                ):
+                    j += 1
+                # Look ahead for = (possibly with whitespace)
+                k = j
+                while k < len(content) and content[k] in (' ', '\t'):
+                    k += 1
+                if k < len(content) and content[k] == '=':
+                    identifier = content[i:j]
+                    result.append('"')
+                    result.append(identifier)
+                    result.append('":')
+                    i = k + 1
+                    continue
+
+            result.append(ch)
+            i += 1
+
+        return ''.join(result)

--- a/qwed_infra/parsers/terraform_parser.py
+++ b/qwed_infra/parsers/terraform_parser.py
@@ -285,19 +285,21 @@ class TerraformParser:
         """Check a single string for unresolved Terraform interpolation.
 
         AWS policy variables are allowed. Terraform interpolation is rejected.
+        Uses brace-depth tracking to correctly handle nested braces (e.g.
+        ``${merge({...}, var.x)}`` — Greptile P1).
         """
         idx = 0
         while True:
             start = value.find("${", idx)
             if start == -1:
                 return
-            end = value.find("}", start)
+            end = TerraformParser._find_matching_brace(value, start + 2)
             if end == -1:
                 return
             inner = value[start + 2:end].strip()
             # AWS policy variables: ${aws:username}, ${saml:sub}, etc.
-            # These contain a colon and are NOT Terraform interpolation.
-            if ":" in inner:
+            # These contain a colon AND have no nested braces.
+            if ":" in inner and "{" not in inner:
                 idx = end + 1
                 continue
             # Terraform interpolation: ${var.name}, ${local.x}, ${module.y}
@@ -307,6 +309,14 @@ class TerraformParser:
                     f"Terraform interpolation '{value}' — cannot extract "
                     f"deterministically. Resolve variables before parsing."
                 )
+            # Contains nested braces (e.g. merge({...}, ...)) — Terraform
+            # function call, not an AWS policy variable. Fail-closed.
+            if "{" in inner or "(" in inner:
+                raise ValueError(
+                    f"aws_iam_policy '{res_name}': policy contains unresolved "
+                    f"Terraform interpolation '{value}' — contains function "
+                    f"calls or nested maps. Resolve before parsing."
+                )
             # Unknown ${...} without a colon — fail-closed
             raise ValueError(
                 f"aws_iam_policy '{res_name}': policy contains unresolved "
@@ -314,6 +324,26 @@ class TerraformParser:
                 f"If this is an AWS policy variable, it must use a colon "
                 f"(e.g. ${{aws:username}})."
             )
+
+    @staticmethod
+    def _find_matching_brace(value: str, start: int) -> int:
+        """Find the matching closing ``}`` for a ``${`` at the given start
+        position. Tracks brace depth to handle nested braces (e.g.
+        ``${merge({...}, var.x)}``).
+
+        Returns the index of the matching ``}`` or -1 if not found.
+        """
+        depth = 1
+        i = start
+        while i < len(value):
+            if value[i] == '{':
+                depth += 1
+            elif value[i] == '}':
+                depth -= 1
+                if depth == 0:
+                    return i
+            i += 1
+        return -1
 
     @staticmethod
     def _extract_policy_document(
@@ -512,34 +542,39 @@ class TerraformParser:
         i = 0
         while i < len(content):
             ch = content[i]
-
             if ch in ('"', "'"):
-                quote = ch
-                # Convert single quotes to double quotes for valid JSON output
-                result.append('"')
-                i += 1
-                while i < len(content):
-                    if content[i] == '\\' and i + 1 < len(content):
-                        # Preserve escape sequences
-                        result.append(content[i])
-                        result.append(content[i + 1])
-                        i += 2
-                        continue
-                    if content[i] == quote:
-                        result.append('"')
-                        i += 1
-                        break
-                    # Escape any unescaped double quotes inside the value
-                    if content[i] == '"' and quote == "'":
-                        result.append('\\"')
-                        i += 1
-                        continue
-                    result.append(content[i])
-                    i += 1
+                i = TerraformParser._copy_string_to_json(result, content, i)
                 continue
-
             i = TerraformParser._try_identifier_equals(result, content, i)
         return ''.join(result)
+
+    @staticmethod
+    def _copy_string_to_json(result: List[str], content: str, i: int) -> int:
+        """Copy a quoted string from content into result, converting single
+        quotes to double quotes for valid JSON output.
+
+        Returns the index after the closing quote. Handles escape sequences
+        and escapes any unescaped double quotes inside single-quoted strings.
+        """
+        quote = content[i]
+        result.append('"')
+        i += 1
+        while i < len(content):
+            if content[i] == '\\' and i + 1 < len(content):
+                result.append(content[i])
+                result.append(content[i + 1])
+                i += 2
+                continue
+            if content[i] == quote:
+                result.append('"')
+                return i + 1
+            if content[i] == '"' and quote == "'":
+                result.append('\\"')
+                i += 1
+                continue
+            result.append(content[i])
+            i += 1
+        return i
 
     @staticmethod
     def _try_identifier_equals(

--- a/qwed_infra/parsers/terraform_parser.py
+++ b/qwed_infra/parsers/terraform_parser.py
@@ -290,7 +290,11 @@ class TerraformParser:
                 return
             end = TerraformParser._find_matching_brace(value, start + 2)
             if end == -1:
-                return
+                raise ValueError(
+                    f"aws_iam_policy '{res_name}': policy contains unterminated "
+                    f"interpolation in '{value}' — cannot verify "
+                    f"deterministically. Refusing to emit a placeholder."
+                )
             inner = value[start + 2:end].strip()
             # AWS policy variables: ${aws:username}, ${saml:sub}, etc.
             # Strictly whitelist known AWS namespaces to avoid false-negatives

--- a/qwed_infra/parsers/terraform_parser.py
+++ b/qwed_infra/parsers/terraform_parser.py
@@ -1,32 +1,60 @@
+import json
 import hcl2
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List
 from pathlib import Path
+
+
+class ParseError(Exception):
+    """Raised when Terraform parsing fails and cannot produce a trustworthy model.
+
+    Fail-closed: downstream guards must not run on a partial model. If any .tf
+    file fails to parse or any resource fails to normalize, the entire parse
+    result is untrustworthy and this exception is raised with the full list of
+    errors collected.
+    """
+
+    def __init__(self, errors: List[str]):
+        self.errors = errors
+        super().__init__(f"Parse failed with {len(errors)} error(s):\n" + "\n".join(f"  - {e}" for e in errors))
+
 
 class TerraformParser:
     """
     Parses Terraform (.tf) files into a unified dictionary structure
     compatible with QWED Guards (IamGuard, NetworkGuard, CostGuard).
+
+    Fail-closed: if any .tf file cannot be parsed or any resource cannot be
+    normalized, ParseError is raised with the full list of errors. Downstream
+    guards must not run on a partial model.
     """
 
     def parse_directory(self, directory_path: str) -> Dict[str, Any]:
         """
         Reads all .tf files in a directory and aggregates resources.
+
+        Raises:
+            ParseError: if any .tf file fails to parse or any resource fails
+                to normalize. The exception carries a list of all errors.
         """
         path = Path(directory_path)
         combined_hcl = {}
-        
+        errors: List[str] = []
+
         # 1. Read and merge generic HCL structure
-        for tf_file in path.glob("*.tf"):
+        for tf_file in sorted(path.glob("*.tf")):
             with open(tf_file, 'r') as f:
                 try:
                     data = hcl2.load(f)
-                    # Merge logic (simplified: appending lists)
                     for key, val in data.items():
                         if key not in combined_hcl:
                             combined_hcl[key] = []
                         combined_hcl[key].extend(val)
                 except Exception as e:
-                    print(f"Error parsing {tf_file}: {e}")
+                    errors.append(f"Failed to parse {tf_file.name}: {e}")
+                    continue
+
+        if errors:
+            raise ParseError(errors)
 
         # 2. Normalize to QWED Internal Schema
         qwed_resources = {
@@ -36,62 +64,66 @@ class TerraformParser:
             "security_groups": [],
             "volumes": []
         }
-        
+
         resources = combined_hcl.get("resource", [])
-        
+
         for resource_block in resources:
             for res_type, res_dict in resource_block.items():
-                # res_dict is usually { "resource_name": { config } }
                 for res_name, config in res_dict.items():
-                    normalized = self._normalize_resource(res_type, res_name, config)
-                    if normalized:
-                        cat = normalized["category"]
-                        qwed_resources[cat].append(normalized["data"])
-                        
+                    try:
+                        normalized = self._normalize_resource(res_type, res_name, config)
+                        if normalized:
+                            cat = normalized["category"]
+                            qwed_resources[cat].append(normalized["data"])
+                    except ParseError:
+                        raise
+                    except Exception as e:
+                        errors.append(f"Failed to normalize {res_type}.{res_name}: {e}")
+
+        if errors:
+            raise ParseError(errors)
+
         return qwed_resources
 
     def _normalize_resource(self, res_type: str, res_name: str, config: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """
         Maps generic Terraform resource types to QWED schema.
+
+        Raises:
+            ValueError: if a resource cannot be faithfully normalized (e.g.
+                IAM policy body cannot be extracted). The caller catches this
+                and converts it into a ParseError entry.
         """
         # --- Compute ---
         if res_type == "aws_instance":
+            instance_type = config.get("instance_type")
+            if instance_type is None:
+                raise ValueError(
+                    f"aws_instance '{res_name}' has no instance_type — cannot "
+                    f"deterministically normalize. Refusing to assume a default."
+                )
             return {
                 "category": "instances",
                 "data": {
-                    "id": res_name, # Terraform logical ID
-                    "instance_type": config.get("instance_type", "t2.micro"),
-                    "count": config.get("count", 1) # TODO: Handle variable interpolation
+                    "id": res_name,
+                    "instance_type": instance_type,
+                    "count": config.get("count", 1)
                 }
             }
-            
+
         # --- IAM ---
         if res_type == "aws_iam_policy":
             policy_json = config.get("policy")
-            try:
-                # Often extracted as string (jsonencode), need to parse if string
-                if isinstance(policy_json, str):
-                    # In hcl2 parsing, this might come as "${jsonencode(...)}" or raw heredoc
-                    # For simplicity, let's assume raw dict if native hcl, or skip interpolation for v0.1
-                    pass 
-                
-                # If it's pure dict (rare in real TF unless using data sources, usually string)
-                # Let's mock the policy extraction for demo purposes or simplistic structure
-                statements = [] 
-                # This is hard: Real TF parsing requires evaluating 'jsonencode'. 
-                # For v0.1, we might look for 'statement' blocks if defined natively, or raw JSON strings.
-                
-                return {
-                    "category": "policies",
-                    "data": {
-                        "id": res_name,
-                        "Version": "2012-10-17",
-                        "Statement": statements # Placeholder until we implement JSON string parser
-                    }
+            statements = self._extract_policy_statements(res_name, policy_json)
+
+            return {
+                "category": "policies",
+                "data": {
+                    "id": res_name,
+                    "Version": "2012-10-17",
+                    "Statement": statements
                 }
-            except Exception as exc:  # noqa: BLE001
-                print(f"Failed to normalize aws_iam_policy '{res_name}': {exc}")
-                return None
+            }
 
         # --- Storage ---
         if res_type == "aws_ebs_volume":
@@ -102,5 +134,81 @@ class TerraformParser:
                     "size_gb": config.get("size", 10)
                 }
             }
-            
+
         return None
+
+    @staticmethod
+    def _extract_policy_statements(res_name: str, policy_body: Any) -> List[Dict[str, Any]]:
+        """
+        Deterministically extract IAM policy statements from a Terraform
+        aws_iam_policy resource.
+
+        hcl2 parses jsonencode({...}) as a dict directly. Heredoc and raw
+        string policies come through as strings. Variable interpolation
+        (file(), var.x) cannot be resolved and must fail-closed.
+
+        Raises:
+            ValueError: if the policy body cannot be faithfully extracted.
+        """
+        if policy_body is None:
+            raise ValueError(
+                f"aws_iam_policy '{res_name}' has no policy body — cannot "
+                f"extract statements. Refusing to emit an empty placeholder."
+            )
+
+        # Case 1: hcl2 parsed jsonencode(...) as a dict
+        if isinstance(policy_body, dict):
+            if "Statement" not in policy_body:
+                raise ValueError(
+                    f"aws_iam_policy '{res_name}': jsonencode policy body has "
+                    f"no 'Statement' key — cannot extract."
+                )
+            statements = policy_body["Statement"]
+            if not isinstance(statements, list):
+                raise ValueError(
+                    f"aws_iam_policy '{res_name}': jsonencode policy 'Statement' "
+                    f"is not a list — cannot extract."
+                )
+            return statements
+
+        # Case 2: heredoc or raw JSON string
+        if isinstance(policy_body, str):
+            stripped = policy_body.strip()
+            if not stripped:
+                raise ValueError(
+                    f"aws_iam_policy '{res_name}': policy body is an empty "
+                    f"string — cannot extract statements."
+                )
+
+            # hcl2 sometimes wraps strings in ${...} interpolation syntax
+            if stripped.startswith("${") and stripped.endswith("}"):
+                stripped = stripped[2:-1].strip()
+
+            try:
+                parsed = json.loads(stripped)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"aws_iam_policy '{res_name}': policy string is not valid "
+                    f"JSON and cannot be resolved (may use variable interpolation "
+                    f"like file() or var.x) — {exc}. Refusing to emit a placeholder."
+                ) from exc
+
+            if "Statement" not in parsed:
+                raise ValueError(
+                    f"aws_iam_policy '{res_name}': parsed JSON policy has no "
+                    f"'Statement' key — cannot extract."
+                )
+            statements = parsed["Statement"]
+            if not isinstance(statements, list):
+                raise ValueError(
+                    f"aws_iam_policy '{res_name}': parsed JSON 'Statement' "
+                    f"is not a list — cannot extract."
+                )
+            return statements
+
+        # Case 3: unsupported type (e.g. list, int, custom object)
+        raise ValueError(
+            f"aws_iam_policy '{res_name}': policy body is of type "
+            f"{type(policy_body).__name__} — cannot extract. Supported forms: "
+            f"jsonencode dict, JSON string, or heredoc."
+        )

--- a/qwed_infra/parsers/terraform_parser.py
+++ b/qwed_infra/parsers/terraform_parser.py
@@ -398,26 +398,18 @@ class TerraformParser:
         depth, and extracts the content between the opening ``(`` and
         its matching ``)``.
 
+        Handles both double-quoted and single-quoted strings.
+
         (Sentry MEDIUM — fixed-length suffix slicing was brittle.)
         """
         prefix = "${jsonencode("
         start = len(prefix)
         depth = 1
-        in_string = False
         i = start
         while i < len(raw):
             ch = raw[i]
-            if in_string:
-                if ch == '\\' and i + 1 < len(raw):
-                    i += 2
-                    continue
-                if ch == '"':
-                    in_string = False
-                i += 1
-                continue
-            if ch == '"':
-                in_string = True
-                i += 1
+            if ch in ('"', "'"):
+                i = TerraformParser._skip_string(raw, i, ch)
                 continue
             if ch == '(':
                 depth += 1
@@ -430,6 +422,22 @@ class TerraformParser:
             f"aws_iam_policy '{res_name}': unterminated jsonencode() — "
             f"no matching closing parenthesis found."
         )
+
+    @staticmethod
+    def _skip_string(raw: str, i: int, quote: str) -> int:
+        """Skip a quoted string starting at position i. Returns the index
+        after the closing quote. Handles escaped quotes (``\\"`` and ``\\'``).
+        """
+        i += 1
+        while i < len(raw):
+            ch = raw[i]
+            if ch == '\\' and i + 1 < len(raw):
+                i += 2
+                continue
+            if ch == quote:
+                return i + 1
+            i += 1
+        return i
 
     @staticmethod
     def _parse_hcl_jsonencode_content(

--- a/qwed_infra/parsers/terraform_parser.py
+++ b/qwed_infra/parsers/terraform_parser.py
@@ -53,7 +53,10 @@ class TerraformParser:
                     for key, val in data.items():
                         if key not in combined_hcl:
                             combined_hcl[key] = []
-                        combined_hcl[key].extend(val)
+                        if isinstance(val, list):
+                            combined_hcl[key].extend(val)
+                        else:
+                            combined_hcl[key].append(val)
             except Exception as e:  # noqa: BLE001
                 errors.append(f"Failed to parse {tf_file.name}: {e}")
                 continue
@@ -507,25 +510,23 @@ class TerraformParser:
         """
         result: List[str] = []
         i = 0
-        in_string = False
         while i < len(content):
             ch = content[i]
 
-            if in_string:
-                result.append(ch)
-                if ch == '\\' and i + 1 < len(content):
-                    result.append(content[i + 1])
-                    i += 2
-                    continue
-                if ch == '"':
-                    in_string = False
-                i += 1
-                continue
-
-            if ch == '"':
-                in_string = True
+            if ch in ('"', "'"):
+                quote = ch
                 result.append(ch)
                 i += 1
+                while i < len(content):
+                    result.append(content[i])
+                    if content[i] == '\\' and i + 1 < len(content):
+                        result.append(content[i + 1])
+                        i += 2
+                        continue
+                    if content[i] == quote:
+                        i += 1
+                        break
+                    i += 1
                 continue
 
             i = TerraformParser._try_identifier_equals(result, content, i)
@@ -549,7 +550,9 @@ class TerraformParser:
             k = j
             while k < len(content) and content[k] in (' ', '\t'):
                 k += 1
-            if k < len(content) and content[k] == '=':
+            if k < len(content) and content[k] == '=' and (
+                k + 1 >= len(content) or content[k + 1] != '='
+            ):
                 result.append('"')
                 result.append(content[i:j])
                 result.append('":')

--- a/qwed_infra/parsers/terraform_parser.py
+++ b/qwed_infra/parsers/terraform_parser.py
@@ -1,5 +1,6 @@
 import ast
 import json
+import re
 import hcl2
 from typing import Dict, Any, Optional, List
 from pathlib import Path
@@ -49,6 +50,7 @@ class TerraformParser:
             try:
                 with open(tf_file, "r") as f:
                     data = hcl2.load(f)
+                    data = self._normalize_hcl2_output(data)
                     for key, val in data.items():
                         if key not in combined_hcl:
                             combined_hcl[key] = []
@@ -93,6 +95,42 @@ class TerraformParser:
             raise ParseError(errors)
 
         return qwed_resources
+
+    @staticmethod
+    def _normalize_hcl2_output(data: Dict[str, Any]) -> Dict[str, Any]:
+        """Normalize hcl2 output to handle version-specific quirks.
+
+        Some hcl2 versions (notably on CI/Linux) return:
+        - Resource type/name keys with embedded double quotes:
+          ``"\\\"aws_iam_policy\\\""`` instead of ``"aws_iam_policy"``
+        - String attribute values with embedded double quotes:
+          ``"\\\"t3.micro\\\""`` instead of ``"t3.micro"``
+        - A ``__is_block__`` marker key in resource config dicts
+
+        This method strips the embedded quotes and removes ``__is_block__``
+        so downstream normalization sees clean keys and values.
+        """
+        result: Dict[str, Any] = {}
+        for key, val in data.items():
+            clean_key = key.strip('"')
+            result[clean_key] = TerraformParser._normalize_hcl2_value(val)
+        return result
+
+    @staticmethod
+    def _normalize_hcl2_value(val: Any) -> Any:
+        """Recursively normalize an hcl2 value (strip quotes, remove __is_block__)."""
+        if isinstance(val, dict):
+            cleaned = {}
+            for k, v in val.items():
+                if k == "__is_block__":
+                    continue
+                cleaned[k.strip('"')] = TerraformParser._normalize_hcl2_value(v)
+            return cleaned
+        if isinstance(val, list):
+            return [TerraformParser._normalize_hcl2_value(v) for v in val]
+        if isinstance(val, str):
+            return val.strip('"')
+        return val
 
     def _normalize_resource(
         self, res_type: str, res_name: str, config: Any
@@ -310,23 +348,40 @@ class TerraformParser:
     ) -> Dict[str, Any]:
         """Parse the inner content of a ${jsonencode(...)} interpolation.
 
-        hcl2 converts HCL map syntax to Python literal syntax with single
-        quotes (e.g. ``{'Version': '2012-10-17', ...}``) — NOT valid JSON.
-        We use ``ast.literal_eval`` which safely evaluates Python literals
-        (dict, list, str, num, bool, None) without executing arbitrary code.
+        hcl2 outputs the jsonencode content in HCL map syntax, which uses
+        ``=`` instead of ``:`` for key-value pairs and may have unquoted
+        keys: ``{Version = "2012-10-17", ...}``. This is neither valid JSON
+        nor valid Python.
+
+        We convert HCL map syntax to JSON by:
+        1. Quoting unquoted keys (``Version`` → ``"Version"``)
+        2. Replacing ``=`` with ``:`` between keys and values
+        3. Parsing the resulting JSON
 
         Raises:
             ValueError: if the content cannot be parsed as a dict.
         """
         content = content.strip()
+
+        # Convert HCL map syntax to JSON:
+        # {Version = "x"} → {"Version": "x"}
+        # Match unquoted word keys followed by = (not inside string values)
+        json_content = re.sub(
+            r'(\b[A-Za-z_]\w*)\s*=', r'"\1":', content
+        )
+
         try:
-            parsed = ast.literal_eval(content)
-        except (ValueError, SyntaxError) as exc:
-            raise ValueError(
-                f"aws_iam_policy '{res_name}': jsonencode content is not "
-                f"valid Python literal — {exc}. This may indicate unsupported "
-                f"HCL constructs inside the jsonencode call."
-            ) from exc
+            parsed = json.loads(json_content)
+        except json.JSONDecodeError:
+            # Fallback: try ast.literal_eval for Python literal syntax
+            try:
+                parsed = ast.literal_eval(content)
+            except (ValueError, SyntaxError) as exc:
+                raise ValueError(
+                    f"aws_iam_policy '{res_name}': jsonencode content is not "
+                    f"valid JSON or Python literal — {exc}. This may indicate "
+                    f"unsupported HCL constructs inside the jsonencode call."
+                ) from exc
 
         if not isinstance(parsed, dict):
             raise ValueError(

--- a/tests/test_terraform_parser.py
+++ b/tests/test_terraform_parser.py
@@ -268,6 +268,70 @@ class TestNormalizeResource:
         result = TerraformParser._normalize_hcl2_value('""nested""')
         assert result == '"nested"'
 
+    def test_hcl_map_to_json_handles_escaped_quotes(self, parser):
+        """_hcl_map_to_json must handle escaped quotes in string values (Sentry HIGH)."""
+        hcl_content = r'{Description = "He said \"hello\""}'
+        result = TerraformParser._hcl_map_to_json(hcl_content)
+        # The escaped quotes must be preserved inside the string
+        assert r'\"hello\"' in result
+        # Key must be quoted
+        assert '"Description":' in result
+
+    def test_aws_policy_variables_allowed(self, parser):
+        """AWS IAM policy variables like ${aws:username} must NOT be rejected (Sentry HIGH)."""
+        policy_body = {
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::bucket/${aws:username}/*"
+            }]
+        }
+        result = parser._normalize_resource("aws_iam_policy", "abac", {"policy": policy_body})
+        assert result is not None
+        assert len(result["data"]["Statement"]) == 1
+
+    def test_aws_saml_variables_allowed(self, parser):
+        """AWS SAML policy variables must NOT be rejected."""
+        policy_body = {
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": "sts:AssumeRoleWithSAML",
+                "Resource": "*",
+                "Condition": {"StringEquals": {"SAML:aud": "https://signin.aws.amazon.com/saml"}}
+            }]
+        }
+        result = parser._normalize_resource("aws_iam_policy", "saml", {"policy": policy_body})
+        assert result is not None
+
+    def test_terraform_var_interpolation_still_rejected(self, parser):
+        """Terraform ${var.x} interpolation must still be rejected."""
+        policy_body = {
+            "Version": "2012-10-17",
+            "Statement": [{"Effect": "Allow", "Action": "${var.action}", "Resource": "*"}]
+        }
+        with pytest.raises(ValueError, match="unresolved Terraform interpolation"):
+            parser._normalize_resource("aws_iam_policy", "var_interp", {"policy": policy_body})
+
+    def test_terraform_local_interpolation_rejected(self, parser):
+        """Terraform ${local.x} interpolation must be rejected."""
+        policy_body = {
+            "Version": "2012-10-17",
+            "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "${local.bucket}"}]
+        }
+        with pytest.raises(ValueError, match="unresolved Terraform interpolation"):
+            parser._normalize_resource("aws_iam_policy", "local_interp", {"policy": policy_body})
+
+    def test_unknown_interpolation_without_colon_rejected(self, parser):
+        """Unknown ${...} without a colon must fail-closed."""
+        policy_body = {
+            "Version": "2012-10-17",
+            "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "${something}"}]
+        }
+        with pytest.raises(ValueError, match="unresolved interpolation"):
+            parser._normalize_resource("aws_iam_policy", "unknown_interp", {"policy": policy_body})
+
     def test_aws_iam_policy_dict_no_statement_fails_closed(self, parser):
         """Dict policy without Statement key must fail-closed (Issue #9)."""
         with pytest.raises(ValueError, match="no 'Statement' key"):

--- a/tests/test_terraform_parser.py
+++ b/tests/test_terraform_parser.py
@@ -349,3 +349,87 @@ class TestParserFailClosed:
         assert len(policies[0]["Statement"]) == 1
         assert policies[0]["Statement"][0]["Action"] == "*"
         assert policies[0]["Statement"][0]["Resource"] == "*"
+
+    def test_jsonencode_policy_real_hcl2_integration(self, parser, tmp_path):
+        """Integration test with real hcl2.load — jsonencode returns ${jsonencode(...)} string.
+
+        This test does NOT mock hcl2. It verifies that the parser correctly
+        handles the actual hcl2 output format where jsonencode({...}) is
+        returned as a string interpolation, not a parsed dict.
+        (Sentry CRITICAL + CodeRabbit Major)
+        """
+        tf_file = tmp_path / "iam.tf"
+        tf_file.write_text('''
+resource "aws_iam_policy" "admin_policy" {
+  name = "admin_policy"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "*"
+        Resource = "*"
+      }
+    ]
+  })
+}
+''')
+
+        resources = parser.parse_directory(str(tmp_path))
+        policies = resources["policies"]
+        assert len(policies) == 1
+        assert policies[0]["id"] == "admin_policy"
+        assert policies[0]["Version"] == "2012-10-17"
+        assert len(policies[0]["Statement"]) == 1
+        stmt = policies[0]["Statement"][0]
+        assert stmt["Effect"] == "Allow"
+        assert stmt["Action"] == "*"
+        assert stmt["Resource"] == "*"
+
+    def test_jsonencode_policy_real_hcl2_multiple_statements(self, parser, tmp_path):
+        """Integration test: real hcl2 with multiple policy statements."""
+        tf_file = tmp_path / "iam.tf"
+        tf_file.write_text('''
+resource "aws_iam_policy" "multi_policy" {
+  name = "multi"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "s3:GetObject"
+        Resource = "arn:aws:s3:::bucket/*"
+      },
+      {
+        Effect = "Deny"
+        Action = "iam:DeleteUser"
+        Resource = "*"
+      }
+    ]
+  })
+}
+''')
+
+        resources = parser.parse_directory(str(tmp_path))
+        policies = resources["policies"]
+        assert len(policies) == 1
+        assert len(policies[0]["Statement"]) == 2
+        assert policies[0]["Statement"][0]["Effect"] == "Allow"
+        assert policies[0]["Statement"][1]["Effect"] == "Deny"
+
+    def test_instance_real_hcl2_integration(self, parser, tmp_path):
+        """Integration test: real hcl2 parsing of aws_instance with list-wrapped values."""
+        tf_file = tmp_path / "main.tf"
+        tf_file.write_text('''
+resource "aws_instance" "web" {
+  instance_type = "t3.micro"
+  count = 2
+}
+''')
+
+        resources = parser.parse_directory(str(tmp_path))
+        instances = resources["instances"]
+        assert len(instances) == 1
+        assert instances[0]["id"] == "web"
+        assert instances[0]["instance_type"] == "t3.micro"
+        assert instances[0]["count"] == 2

--- a/tests/test_terraform_parser.py
+++ b/tests/test_terraform_parser.py
@@ -195,6 +195,47 @@ class TestNormalizeResource:
         with pytest.raises(ValueError, match="not a dict"):
             parser._normalize_resource("aws_instance", "web", "not_a_dict")
 
+    def test_aws_iam_policy_statement_non_dict_fails_closed(self, parser):
+        """Statement entry that is not a dict must fail-closed (CodeRabbit security)."""
+        policy_body = {
+            "Version": "2012-10-17",
+            "Statement": [{"Effect": "Allow"}, "not_a_dict"]
+        }
+        with pytest.raises(ValueError, match="not a dict"):
+            parser._normalize_resource("aws_iam_policy", "bad_stmt", {"policy": policy_body})
+
+    def test_aws_iam_policy_interpolation_in_action_fails_closed(self, parser):
+        """Unresolved Terraform interpolation in policy values must fail-closed (CodeRabbit security)."""
+        policy_body = {
+            "Version": "2012-10-17",
+            "Statement": [{"Effect": "Allow", "Action": "${var.admin_actions}", "Resource": "*"}]
+        }
+        with pytest.raises(ValueError, match="unresolved Terraform interpolation"):
+            parser._normalize_resource("aws_iam_policy", "interp", {"policy": policy_body})
+
+    def test_aws_iam_policy_interpolation_in_resource_fails_closed(self, parser):
+        """Unresolved interpolation in Resource field must fail-closed."""
+        policy_body = {
+            "Version": "2012-10-17",
+            "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "${var.bucket_arn}"}]
+        }
+        with pytest.raises(ValueError, match="unresolved Terraform interpolation"):
+            parser._normalize_resource("aws_iam_policy", "interp_res", {"policy": policy_body})
+
+    def test_aws_iam_policy_interpolation_in_nested_dict_fails_closed(self, parser):
+        """Interpolation in nested Condition dict must fail-closed (recursive check)."""
+        policy_body = {
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": "s3:*",
+                "Resource": "*",
+                "Condition": {"StringEquals": {"aws:SourceIp": "${var.allowed_ip}"}}
+            }]
+        }
+        with pytest.raises(ValueError, match="unresolved Terraform interpolation"):
+            parser._normalize_resource("aws_iam_policy", "nested_interp", {"policy": policy_body})
+
     def test_aws_iam_policy_dict_no_statement_fails_closed(self, parser):
         """Dict policy without Statement key must fail-closed (Issue #9)."""
         with pytest.raises(ValueError, match="no 'Statement' key"):

--- a/tests/test_terraform_parser.py
+++ b/tests/test_terraform_parser.py
@@ -1,5 +1,6 @@
+import json
 import pytest
-from qwed_infra.parsers.terraform_parser import TerraformParser
+from qwed_infra.parsers.terraform_parser import TerraformParser, ParseError
 import os
 from unittest.mock import patch
 
@@ -10,10 +11,9 @@ def parser():
 @patch('qwed_infra.parsers.terraform_parser.hcl2.load')
 def test_parse_simple_infrastructure(mock_hcl2_load, parser, tmp_path):
     """Integration test: mock hcl2.load to return known HCL structure and verify parsing."""
-    # Create a dummy .tf file so the glob finds something
     tf_file = tmp_path / "test.tf"
     tf_file.write_text("")
-    
+
     mock_hcl2_load.return_value = {
         "resource": [
             {"aws_instance": {"web": {"instance_type": "t3.micro", "count": 2}}},
@@ -21,23 +21,21 @@ def test_parse_simple_infrastructure(mock_hcl2_load, parser, tmp_path):
             {"aws_ebs_volume": {"data_vol": {"size": 40}}},
         ]
     }
-    
+
     resources = parser.parse_directory(str(tmp_path))
     mock_hcl2_load.assert_called_once()
-    
+
     # Verify Instances
     instances = resources["instances"]
     assert len(instances) == 2
-    
-    # Web Nodes
+
     web = next(i for i in instances if i["id"] == "web")
     assert web["instance_type"] == "t3.micro"
     assert web["count"] == 2
-    
-    # GPU Node
+
     gpu = next(i for i in instances if i["id"] == "gpu_node")
     assert gpu["instance_type"] == "p4d.24xlarge"
-    assert gpu["count"] == 1 # Default
+    assert gpu["count"] == 1
 
     # Verify Volumes
     volumes = resources["volumes"]
@@ -59,24 +57,105 @@ class TestNormalizeResource:
         assert result["data"]["instance_type"] == "t3.micro"
         assert result["data"]["count"] == 2
 
-    def test_aws_instance_defaults(self, parser):
-        result = parser._normalize_resource("aws_instance", "srv", {})
-        assert result["data"]["instance_type"] == "t2.micro"
-        assert result["data"]["count"] == 1
+    def test_aws_instance_missing_type_fails_closed(self, parser):
+        """Missing instance_type must not default — must fail-closed (Issue #11)."""
+        with pytest.raises(ValueError, match="no instance_type"):
+            parser._normalize_resource("aws_instance", "srv", {})
 
-    def test_aws_iam_policy_normalized(self, parser):
-        result = parser._normalize_resource("aws_iam_policy", "my_policy", {"policy": None})
+    def test_aws_iam_policy_dict_body(self, parser):
+        """jsonencode({...}) parsed by hcl2 as dict — statements extracted."""
+        policy_body = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Effect": "Allow", "Action": "*", "Resource": "*"}
+            ]
+        }
+        result = parser._normalize_resource("aws_iam_policy", "admin_policy", {"policy": policy_body})
         assert result is not None
         assert result["category"] == "policies"
-        assert result["data"]["id"] == "my_policy"
+        assert result["data"]["id"] == "admin_policy"
         assert result["data"]["Version"] == "2012-10-17"
-        assert isinstance(result["data"]["Statement"], list)
+        assert len(result["data"]["Statement"]) == 1
+        assert result["data"]["Statement"][0]["Action"] == "*"
+        assert result["data"]["Statement"][0]["Resource"] == "*"
 
-    def test_aws_iam_policy_with_string_policy(self, parser):
-        # String policy (jsonencode placeholder) — should still return a skeleton policy
-        result = parser._normalize_resource("aws_iam_policy", "str_policy", {"policy": '{"Statement":[]}'})
+    def test_aws_iam_policy_json_string(self, parser):
+        """Raw JSON string policy — parsed and statements extracted."""
+        policy_str = json.dumps({
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Effect": "Allow", "Action": "s3:GetObject", "Resource": "arn:aws:s3:::bucket/*"}
+            ]
+        })
+        result = parser._normalize_resource("aws_iam_policy", "s3_policy", {"policy": policy_str})
         assert result is not None
         assert result["category"] == "policies"
+        assert len(result["data"]["Statement"]) == 1
+        assert result["data"]["Statement"][0]["Action"] == "s3:GetObject"
+
+    def test_aws_iam_policy_heredoc_with_interpolation_wrapper(self, parser):
+        """hcl2 sometimes wraps heredoc strings in ${...} — should be unwrapped."""
+        policy_str = '${' + json.dumps({
+            "Version": "2012-10-17",
+            "Statement": [{"Effect": "Deny", "Action": "iam:DeleteUser", "Resource": "*"}]
+        }) + '}'
+        result = parser._normalize_resource("aws_iam_policy", "deny_policy", {"policy": policy_str})
+        assert result is not None
+        assert len(result["data"]["Statement"]) == 1
+        assert result["data"]["Statement"][0]["Effect"] == "Deny"
+
+    def test_aws_iam_policy_empty_statements_list(self, parser):
+        """Policy with empty Statement list is valid — no statements to verify."""
+        result = parser._normalize_resource("aws_iam_policy", "empty_policy", {
+            "policy": {"Version": "2012-10-17", "Statement": []}
+        })
+        assert result is not None
+        assert result["data"]["Statement"] == []
+
+    def test_aws_iam_policy_no_policy_body_fails_closed(self, parser):
+        """Missing policy body must fail-closed — not emit empty placeholder (Issue #9)."""
+        with pytest.raises(ValueError, match="no policy body"):
+            parser._normalize_resource("aws_iam_policy", "bad_policy", {})
+
+    def test_aws_iam_policy_none_policy_fails_closed(self, parser):
+        """None policy body must fail-closed — not emit empty placeholder (Issue #9)."""
+        with pytest.raises(ValueError, match="no policy body"):
+            parser._normalize_resource("aws_iam_policy", "null_policy", {"policy": None})
+
+    def test_aws_iam_policy_empty_string_fails_closed(self, parser):
+        """Empty string policy body must fail-closed (Issue #9)."""
+        with pytest.raises(ValueError, match="empty string"):
+            parser._normalize_resource("aws_iam_policy", "empty_str", {"policy": ""})
+
+    def test_aws_iam_policy_invalid_json_fails_closed(self, parser):
+        """Non-JSON string (e.g. variable interpolation) must fail-closed (Issue #9)."""
+        with pytest.raises(ValueError, match="not valid JSON"):
+            parser._normalize_resource("aws_iam_policy", "interp", {"policy": "var.policy_json"})
+
+    def test_aws_iam_policy_unsupported_type_fails_closed(self, parser):
+        """Unsupported policy body type must fail-closed (Issue #9)."""
+        with pytest.raises(ValueError, match="cannot extract"):
+            parser._normalize_resource("aws_iam_policy", "list_policy", {"policy": [1, 2, 3]})
+
+    def test_aws_iam_policy_dict_no_statement_fails_closed(self, parser):
+        """Dict policy without Statement key must fail-closed (Issue #9)."""
+        with pytest.raises(ValueError, match="no 'Statement' key"):
+            parser._normalize_resource("aws_iam_policy", "no_stmt", {"policy": {"Version": "2012-10-17"}})
+
+    def test_aws_iam_policy_wildcard_admin_not_stripped(self, parser):
+        """Critical: wildcard admin policy must never collapse into empty statements (Issue #9)."""
+        policy_body = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Effect": "Allow", "Action": "*", "Resource": "*"}
+            ]
+        }
+        result = parser._normalize_resource("aws_iam_policy", "admin", {"policy": policy_body})
+        assert result is not None
+        assert len(result["data"]["Statement"]) == 1
+        stmt = result["data"]["Statement"][0]
+        assert stmt["Action"] == "*"
+        assert stmt["Resource"] == "*"
 
     def test_aws_ebs_volume_normalized(self, parser):
         result = parser._normalize_resource("aws_ebs_volume", "my_vol", {"size": 100})
@@ -93,34 +172,134 @@ class TestNormalizeResource:
         assert result is None
 
     def test_aws_security_group_returns_none(self, parser):
-        # Security groups are not yet mapped — should return None (not crash)
         result = parser._normalize_resource("aws_security_group", "sg_web", {"ingress": []})
         assert result is None
 
+
+# ------------------------------------------------------------------
+# Fail-closed parser behavior (Issue #8)
+# ------------------------------------------------------------------
+
+class TestParserFailClosed:
     @patch('qwed_infra.parsers.terraform_parser.hcl2.load')
-    def test_parse_directory_hcl2_error(self, mock_hcl2_load, parser, tmp_path):
-        # Create a dummy .tf file in a temporary directory
+    def test_parse_error_raises_parse_error(self, mock_hcl2_load, parser, tmp_path):
+        """Malformed .tf file must raise ParseError, not return partial model (Issue #8)."""
         tf_file = tmp_path / "bad.tf"
         tf_file.write_text("invalid hcl")
-        
-        # Configure the mock to raise an exception
+
         mock_hcl2_load.side_effect = Exception("Mocked HCL parsing error")
-        
-        # Call parse_directory, it should catch the exception and return empty resources
+
+        with pytest.raises(ParseError) as exc_info:
+            parser.parse_directory(str(tmp_path))
+
+        assert len(exc_info.value.errors) == 1
+        assert "Mocked HCL parsing error" in exc_info.value.errors[0]
+
+    @patch('qwed_infra.parsers.terraform_parser.hcl2.load')
+    def test_one_bad_file_among_multiple_raises(self, mock_hcl2_load, parser, tmp_path):
+        """One bad .tf file among multiple must fail the entire parse (Issue #8)."""
+        (tmp_path / "good.tf").write_text("")
+        (tmp_path / "bad.tf").write_text("")
+
+        call_count = [0]
+        def side_effect(f):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return {"resource": [{"aws_instance": {"web": {"instance_type": "t3.micro"}}}]}
+            raise Exception("HCL parse error in bad.tf")
+
+        mock_hcl2_load.side_effect = side_effect
+
+        with pytest.raises(ParseError) as exc_info:
+            parser.parse_directory(str(tmp_path))
+
+        assert any("HCL parse error" in e for e in exc_info.value.errors)
+
+    @patch('qwed_infra.parsers.terraform_parser.hcl2.load')
+    def test_normalization_error_raises_parse_error(self, mock_hcl2_load, parser, tmp_path):
+        """Normalization failure must raise ParseError, not silently skip (Issue #8)."""
+        tf_file = tmp_path / "test.tf"
+        tf_file.write_text("")
+
+        mock_hcl2_load.return_value = {
+            "resource": [
+                {"aws_iam_policy": {"bad_policy": {"policy": "not_valid_json{{{"}}}
+            ]
+        }
+
+        with pytest.raises(ParseError) as exc_info:
+            parser.parse_directory(str(tmp_path))
+
+        assert any("bad_policy" in e for e in exc_info.value.errors)
+
+    @patch('qwed_infra.parsers.terraform_parser.hcl2.load')
+    def test_missing_instance_type_raises_parse_error(self, mock_hcl2_load, parser, tmp_path):
+        """Missing instance_type must fail-closed, not default to t2.micro (Issue #11)."""
+        tf_file = tmp_path / "test.tf"
+        tf_file.write_text("")
+
+        mock_hcl2_load.return_value = {
+            "resource": [
+                {"aws_instance": {"web": {}}}
+            ]
+        }
+
+        with pytest.raises(ParseError) as exc_info:
+            parser.parse_directory(str(tmp_path))
+
+        assert any("no instance_type" in e for e in exc_info.value.errors)
+
+    @patch('qwed_infra.parsers.terraform_parser.hcl2.load')
+    def test_empty_directory_returns_empty_resources(self, mock_hcl2_load, parser, tmp_path):
+        """Directory with no .tf files should return empty resources, not raise."""
         resources = parser.parse_directory(str(tmp_path))
-        
-        # Verify it handled the error gracefully and returned the empty schema
         assert resources["instances"] == []
         assert resources["policies"] == []
+        assert resources["volumes"] == []
 
-    def test_aws_iam_policy_normalization_error(self, parser):
-        # Create an object that raises an exception when isinstance() checks its __class__
-        class ExplodingPolicy:
-            @property
-            def __class__(self):
-                raise Exception("Mocked IAM normalization error")
-        
-        result = parser._normalize_resource("aws_iam_policy", "bad_policy", {"policy": ExplodingPolicy()})
-        
-        # Should catch the exception and return None
-        assert result is None
+    @patch('qwed_infra.parsers.terraform_parser.hcl2.load')
+    def test_multiple_errors_all_collected(self, mock_hcl2_load, parser, tmp_path):
+        """Multiple parse errors should all be collected in one ParseError (Issue #8)."""
+        (tmp_path / "a.tf").write_text("")
+        (tmp_path / "b.tf").write_text("")
+
+        call_count = [0]
+        def side_effect(f):
+            call_count[0] += 1
+            raise Exception(f"Error in file {call_count[0]}")
+
+        mock_hcl2_load.side_effect = side_effect
+
+        with pytest.raises(ParseError) as exc_info:
+            parser.parse_directory(str(tmp_path))
+
+        assert len(exc_info.value.errors) == 2
+
+    @patch('qwed_infra.parsers.terraform_parser.hcl2.load')
+    def test_jsonencode_policy_extracted_end_to_end(self, mock_hcl2_load, parser, tmp_path):
+        """End-to-end: jsonencode policy with wildcard admin is extracted, not stripped (Issue #9)."""
+        tf_file = tmp_path / "test.tf"
+        tf_file.write_text("")
+
+        mock_hcl2_load.return_value = {
+            "resource": [
+                {"aws_iam_policy": {
+                    "admin_policy": {
+                        "policy": {
+                            "Version": "2012-10-17",
+                            "Statement": [
+                                {"Effect": "Allow", "Action": "*", "Resource": "*"}
+                            ]
+                        }
+                    }
+                }}
+            ]
+        }
+
+        resources = parser.parse_directory(str(tmp_path))
+        policies = resources["policies"]
+        assert len(policies) == 1
+        assert policies[0]["id"] == "admin_policy"
+        assert len(policies[0]["Statement"]) == 1
+        assert policies[0]["Statement"][0]["Action"] == "*"
+        assert policies[0]["Statement"][0]["Resource"] == "*"

--- a/tests/test_terraform_parser.py
+++ b/tests/test_terraform_parser.py
@@ -183,6 +183,18 @@ class TestNormalizeResource:
         result = parser._normalize_resource("aws_instance", "web", {"instance_type": ["t3.micro"]})
         assert result["data"]["instance_type"] == "t3.micro"
 
+    def test_config_list_wrapped_dict(self, parser):
+        """hcl2 on some versions wraps the entire config in a list — must unwrap (CI fix)."""
+        config = [{"instance_type": "t3.micro", "count": 2}]
+        result = parser._normalize_resource("aws_instance", "web", config)
+        assert result["data"]["instance_type"] == "t3.micro"
+        assert result["data"]["count"] == 2
+
+    def test_config_non_dict_non_list_fails_closed(self, parser):
+        """Config that is neither dict nor list must fail-closed."""
+        with pytest.raises(ValueError, match="not a dict"):
+            parser._normalize_resource("aws_instance", "web", "not_a_dict")
+
     def test_aws_iam_policy_dict_no_statement_fails_closed(self, parser):
         """Dict policy without Statement key must fail-closed (Issue #9)."""
         with pytest.raises(ValueError, match="no 'Statement' key"):

--- a/tests/test_terraform_parser.py
+++ b/tests/test_terraform_parser.py
@@ -341,6 +341,28 @@ class TestNormalizeResource:
         with pytest.raises(ValueError, match="unresolved Terraform interpolation"):
             parser._normalize_resource("aws_iam_policy", "nested_brace", {"policy": policy_body})
 
+    @patch('qwed_infra.parsers.terraform_parser.hcl2.load')
+    def test_parse_and_normalization_errors_aggregated(self, mock_hcl2_load, parser, tmp_path):
+        """Both HCL parse errors and normalization errors in one ParseError (Sentry MEDIUM)."""
+        (tmp_path / "bad.tf").write_text("")
+        (tmp_path / "good.tf").write_text("")
+
+        call_count = [0]
+        def side_effect(f):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise Exception("HCL syntax error")
+            return {"resource": [{"aws_instance": {"web": {}}}]}
+
+        mock_hcl2_load.side_effect = side_effect
+
+        with pytest.raises(ParseError) as exc_info:
+            parser.parse_directory(str(tmp_path))
+
+        all_errors = " ".join(exc_info.value.errors)
+        assert "HCL syntax error" in all_errors
+        assert "no instance_type" in all_errors
+
     def test_jsonencode_inner_extraction_with_paren_in_value(self, parser):
         """_extract_jsonencode_inner must handle ) inside string values (Sentry MEDIUM)."""
         raw = '${jsonencode({Version = "2012-10-17", Statement = [{Resource = "arn:aws:s3:::bucket)"}]})}'

--- a/tests/test_terraform_parser.py
+++ b/tests/test_terraform_parser.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 from qwed_infra.parsers.terraform_parser import TerraformParser, ParseError
+import hcl2
 import os
 from unittest.mock import patch
 
@@ -412,7 +413,7 @@ class TestParserFailClosed:
         (Sentry CRITICAL + CodeRabbit Major)
         """
         tf_file = tmp_path / "iam.tf"
-        tf_file.write_text('''
+        tf_content = '''
 resource "aws_iam_policy" "admin_policy" {
   name = "admin_policy"
   policy = jsonencode({
@@ -426,11 +427,21 @@ resource "aws_iam_policy" "admin_policy" {
     ]
   })
 }
-''')
+'''
+        tf_file.write_text(tf_content)
+
+        # Capture raw hcl2 output for diagnostics
+        with open(tf_file, "r") as f:
+            raw_hcl2 = hcl2.load(f)
+        raw_str = json.dumps(raw_hcl2, indent=2, default=str)
 
         resources = parser.parse_directory(str(tmp_path))
         policies = resources["policies"]
-        assert len(policies) == 1
+        assert len(policies) == 1, (
+            f"Expected 1 policy, got {len(policies)}.\n"
+            f"Raw hcl2 output:\n{raw_str}\n"
+            f"Parsed resources: {json.dumps(resources, indent=2, default=str)}"
+        )
         assert policies[0]["id"] == "admin_policy"
         assert policies[0]["Version"] == "2012-10-17"
         assert len(policies[0]["Statement"]) == 1
@@ -442,7 +453,7 @@ resource "aws_iam_policy" "admin_policy" {
     def test_jsonencode_policy_real_hcl2_multiple_statements(self, parser, tmp_path):
         """Integration test: real hcl2 with multiple policy statements."""
         tf_file = tmp_path / "iam.tf"
-        tf_file.write_text('''
+        tf_content = '''
 resource "aws_iam_policy" "multi_policy" {
   name = "multi"
   policy = jsonencode({
@@ -461,11 +472,19 @@ resource "aws_iam_policy" "multi_policy" {
     ]
   })
 }
-''')
+'''
+        tf_file.write_text(tf_content)
+
+        with open(tf_file, "r") as f:
+            raw_hcl2 = hcl2.load(f)
+        raw_str = json.dumps(raw_hcl2, indent=2, default=str)
 
         resources = parser.parse_directory(str(tmp_path))
         policies = resources["policies"]
-        assert len(policies) == 1
+        assert len(policies) == 1, (
+            f"Expected 1 policy, got {len(policies)}.\n"
+            f"Raw hcl2 output:\n{raw_str}"
+        )
         assert len(policies[0]["Statement"]) == 2
         assert policies[0]["Statement"][0]["Effect"] == "Allow"
         assert policies[0]["Statement"][1]["Effect"] == "Deny"
@@ -473,16 +492,24 @@ resource "aws_iam_policy" "multi_policy" {
     def test_instance_real_hcl2_integration(self, parser, tmp_path):
         """Integration test: real hcl2 parsing of aws_instance with list-wrapped values."""
         tf_file = tmp_path / "main.tf"
-        tf_file.write_text('''
+        tf_content = '''
 resource "aws_instance" "web" {
   instance_type = "t3.micro"
   count = 2
 }
-''')
+'''
+        tf_file.write_text(tf_content)
+
+        with open(tf_file, "r") as f:
+            raw_hcl2 = hcl2.load(f)
+        raw_str = json.dumps(raw_hcl2, indent=2, default=str)
 
         resources = parser.parse_directory(str(tmp_path))
         instances = resources["instances"]
-        assert len(instances) == 1
+        assert len(instances) == 1, (
+            f"Expected 1 instance, got {len(instances)}.\n"
+            f"Raw hcl2 output:\n{raw_str}"
+        )
         assert instances[0]["id"] == "web"
         assert instances[0]["instance_type"] == "t3.micro"
         assert instances[0]["count"] == 2

--- a/tests/test_terraform_parser.py
+++ b/tests/test_terraform_parser.py
@@ -364,8 +364,24 @@ class TestNormalizeResource:
         """_hcl_map_to_json must handle = inside single-quoted strings (Sentry HIGH)."""
         hcl_content = "{Tag = 'key=value'}"
         result = TerraformParser._hcl_map_to_json(hcl_content)
-        assert "key=value" in result
-        assert '"Tag":' in result
+        # Single quotes must be converted to double quotes for valid JSON
+        parsed = json.loads(result)
+        assert parsed["Tag"] == "key=value"
+
+    def test_hcl_map_to_json_single_quoted_produces_valid_json(self, parser):
+        """_hcl_map_to_json with single-quoted values must produce valid JSON (Sentry HIGH)."""
+        hcl_content = "{Version = '2012-10-17', Action = '*'}"
+        result = TerraformParser._hcl_map_to_json(hcl_content)
+        parsed = json.loads(result)
+        assert parsed["Version"] == "2012-10-17"
+        assert parsed["Action"] == "*"
+
+    def test_hcl_map_to_json_single_quote_with_double_quote_inside(self, parser):
+        """Single-quoted string containing double quotes must escape them."""
+        hcl_content = "{Desc = 'He said \"hi\"'}"
+        result = TerraformParser._hcl_map_to_json(hcl_content)
+        parsed = json.loads(result)
+        assert parsed["Desc"] == 'He said "hi"'
 
     def test_hcl_map_to_json_double_equals_not_assignment(self, parser):
         """_hcl_map_to_json must not treat == as key-value assignment (Sentry HIGH)."""

--- a/tests/test_terraform_parser.py
+++ b/tests/test_terraform_parser.py
@@ -79,6 +79,15 @@ class TestNormalizeResource:
         assert result["data"]["Statement"][0]["Action"] == "*"
         assert result["data"]["Statement"][0]["Resource"] == "*"
 
+    def test_aws_iam_policy_custom_version_extracted(self, parser):
+        """Version should be extracted from the actual policy document, not hardcoded (Greptile P2)."""
+        policy_body = {
+            "Version": "2024-01-01",
+            "Statement": [{"Effect": "Allow", "Action": "s3:*", "Resource": "*"}]
+        }
+        result = parser._normalize_resource("aws_iam_policy", "v2_policy", {"policy": policy_body})
+        assert result["data"]["Version"] == "2024-01-01"
+
     def test_aws_iam_policy_json_string(self, parser):
         """Raw JSON string policy — parsed and statements extracted."""
         policy_str = json.dumps({
@@ -92,6 +101,15 @@ class TestNormalizeResource:
         assert result["category"] == "policies"
         assert len(result["data"]["Statement"]) == 1
         assert result["data"]["Statement"][0]["Action"] == "s3:GetObject"
+
+    def test_aws_iam_policy_json_string_custom_version(self, parser):
+        """Version extracted from JSON string policy (Greptile P2)."""
+        policy_str = json.dumps({
+            "Version": "2024-01-01",
+            "Statement": [{"Effect": "Deny", "Action": "*", "Resource": "*"}]
+        })
+        result = parser._normalize_resource("aws_iam_policy", "custom_v", {"policy": policy_str})
+        assert result["data"]["Version"] == "2024-01-01"
 
     def test_aws_iam_policy_heredoc_with_interpolation_wrapper(self, parser):
         """hcl2 sometimes wraps heredoc strings in ${...} — should be unwrapped."""
@@ -136,6 +154,34 @@ class TestNormalizeResource:
         """Unsupported policy body type must fail-closed (Issue #9)."""
         with pytest.raises(ValueError, match="cannot extract"):
             parser._normalize_resource("aws_iam_policy", "list_policy", {"policy": [1, 2, 3]})
+
+    def test_aws_iam_policy_hcl2_list_wrapped_dict(self, parser):
+        """hcl2 wraps attributes in single-element lists — must unwrap (CodeRabbit Critical)."""
+        policy_body = {
+            "Version": "2012-10-17",
+            "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "*"}]
+        }
+        # Simulate hcl2 wrapping the policy value in a list
+        result = parser._normalize_resource("aws_iam_policy", "wrapped", {"policy": [policy_body]})
+        assert result is not None
+        assert len(result["data"]["Statement"]) == 1
+        assert result["data"]["Statement"][0]["Action"] == "*"
+
+    def test_aws_iam_policy_hcl2_list_wrapped_string(self, parser):
+        """hcl2 list-wrapped JSON string must be unwrapped and parsed (CodeRabbit Critical)."""
+        policy_str = json.dumps({
+            "Version": "2012-10-17",
+            "Statement": [{"Effect": "Deny", "Action": "iam:*", "Resource": "*"}]
+        })
+        result = parser._normalize_resource("aws_iam_policy", "wrapped_str", {"policy": [policy_str]})
+        assert result is not None
+        assert len(result["data"]["Statement"]) == 1
+        assert result["data"]["Statement"][0]["Effect"] == "Deny"
+
+    def test_aws_instance_hcl2_list_wrapped_type(self, parser):
+        """hcl2 wraps instance_type in a list — must unwrap (CodeRabbit Critical)."""
+        result = parser._normalize_resource("aws_instance", "web", {"instance_type": ["t3.micro"]})
+        assert result["data"]["instance_type"] == "t3.micro"
 
     def test_aws_iam_policy_dict_no_statement_fails_closed(self, parser):
         """Dict policy without Statement key must fail-closed (Issue #9)."""
@@ -198,15 +244,15 @@ class TestParserFailClosed:
     @patch('qwed_infra.parsers.terraform_parser.hcl2.load')
     def test_one_bad_file_among_multiple_raises(self, mock_hcl2_load, parser, tmp_path):
         """One bad .tf file among multiple must fail the entire parse (Issue #8)."""
-        (tmp_path / "good.tf").write_text("")
-        (tmp_path / "bad.tf").write_text("")
+        (tmp_path / "aaa_good.tf").write_text("")
+        (tmp_path / "zzz_bad.tf").write_text("")
 
         call_count = [0]
         def side_effect(f):
             call_count[0] += 1
             if call_count[0] == 1:
                 return {"resource": [{"aws_instance": {"web": {"instance_type": "t3.micro"}}}]}
-            raise Exception("HCL parse error in bad.tf")
+            raise Exception("HCL parse error in bad file")
 
         mock_hcl2_load.side_effect = side_effect
 

--- a/tests/test_terraform_parser.py
+++ b/tests/test_terraform_parser.py
@@ -347,6 +347,19 @@ class TestNormalizeResource:
         with pytest.raises(ValueError, match="unterminated jsonencode"):
             TerraformParser._extract_jsonencode_inner("test", raw)
 
+    def test_jsonencode_inner_extraction_single_quoted_paren(self, parser):
+        """_extract_jsonencode_inner must handle ) inside single-quoted strings (Sentry HIGH)."""
+        raw = "${jsonencode({Resource = 'arn:aws:s3:::bucket)'})}"
+        inner = TerraformParser._extract_jsonencode_inner("test", raw)
+        assert "bucket)" in inner
+        assert inner.endswith("}")
+
+    def test_jsonencode_inner_extraction_escaped_quote(self, parser):
+        """_extract_jsonencode_inner must handle escaped quotes inside strings."""
+        raw = r'${jsonencode({Desc = "He said \"hello)\""})}'
+        inner = TerraformParser._extract_jsonencode_inner("test", raw)
+        assert "hello)" in inner
+
     def test_aws_iam_policy_dict_no_statement_fails_closed(self, parser):
         """Dict policy without Statement key must fail-closed (Issue #9)."""
         with pytest.raises(ValueError, match="no 'Statement' key"):

--- a/tests/test_terraform_parser.py
+++ b/tests/test_terraform_parser.py
@@ -211,7 +211,7 @@ class TestNormalizeResource:
             "Version": "2012-10-17",
             "Statement": [{"Effect": "Allow", "Action": "${var.admin_actions}", "Resource": "*"}]
         }
-        with pytest.raises(ValueError, match="unresolved Terraform interpolation"):
+        with pytest.raises(ValueError, match="unresolved interpolation"):
             parser._normalize_resource("aws_iam_policy", "interp", {"policy": policy_body})
 
     def test_aws_iam_policy_interpolation_in_resource_fails_closed(self, parser):
@@ -220,7 +220,7 @@ class TestNormalizeResource:
             "Version": "2012-10-17",
             "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "${var.bucket_arn}"}]
         }
-        with pytest.raises(ValueError, match="unresolved Terraform interpolation"):
+        with pytest.raises(ValueError, match="unresolved interpolation"):
             parser._normalize_resource("aws_iam_policy", "interp_res", {"policy": policy_body})
 
     def test_aws_iam_policy_interpolation_in_nested_dict_fails_closed(self, parser):
@@ -234,7 +234,7 @@ class TestNormalizeResource:
                 "Condition": {"StringEquals": {"aws:SourceIp": "${var.allowed_ip}"}}
             }]
         }
-        with pytest.raises(ValueError, match="unresolved Terraform interpolation"):
+        with pytest.raises(ValueError, match="unresolved interpolation"):
             parser._normalize_resource("aws_iam_policy", "nested_interp", {"policy": policy_body})
 
     def test_hcl_map_to_json_preserves_equals_in_strings(self, parser):
@@ -311,7 +311,7 @@ class TestNormalizeResource:
             "Version": "2012-10-17",
             "Statement": [{"Effect": "Allow", "Action": "${var.action}", "Resource": "*"}]
         }
-        with pytest.raises(ValueError, match="unresolved Terraform interpolation"):
+        with pytest.raises(ValueError, match="unresolved interpolation"):
             parser._normalize_resource("aws_iam_policy", "var_interp", {"policy": policy_body})
 
     def test_terraform_local_interpolation_rejected(self, parser):
@@ -320,7 +320,7 @@ class TestNormalizeResource:
             "Version": "2012-10-17",
             "Statement": [{"Effect": "Allow", "Action": "*", "Resource": "${local.bucket}"}]
         }
-        with pytest.raises(ValueError, match="unresolved Terraform interpolation"):
+        with pytest.raises(ValueError, match="unresolved interpolation"):
             parser._normalize_resource("aws_iam_policy", "local_interp", {"policy": policy_body})
 
     def test_unknown_interpolation_without_colon_rejected(self, parser):
@@ -338,8 +338,17 @@ class TestNormalizeResource:
             "Version": "2012-10-17",
             "Statement": [{"Effect": "Allow", "Action": '${merge({"Action:": "s3:*"}, var.base)}', "Resource": "*"}]
         }
-        with pytest.raises(ValueError, match="unresolved Terraform interpolation"):
+        with pytest.raises(ValueError, match="unresolved interpolation"):
             parser._normalize_resource("aws_iam_policy", "nested_brace", {"policy": policy_body})
+
+    def test_for_expression_with_colon_rejected(self, parser):
+        """Terraform for-expressions with colons must not bypass the guard (Greptile P1)."""
+        policy_body = {
+            "Version": "2012-10-17",
+            "Statement": [{"Effect": "Allow", "Action": "${[for s in var.actions : s]}", "Resource": "*"}]
+        }
+        with pytest.raises(ValueError, match="unresolved interpolation"):
+            parser._normalize_resource("aws_iam_policy", "for_expr", {"policy": policy_body})
 
     @patch('qwed_infra.parsers.terraform_parser.hcl2.load')
     def test_parse_and_normalization_errors_aggregated(self, mock_hcl2_load, parser, tmp_path):

--- a/tests/test_terraform_parser.py
+++ b/tests/test_terraform_parser.py
@@ -332,6 +332,21 @@ class TestNormalizeResource:
         with pytest.raises(ValueError, match="unresolved interpolation"):
             parser._normalize_resource("aws_iam_policy", "unknown_interp", {"policy": policy_body})
 
+    def test_jsonencode_inner_extraction_with_paren_in_value(self, parser):
+        """_extract_jsonencode_inner must handle ) inside string values (Sentry MEDIUM)."""
+        raw = '${jsonencode({Version = "2012-10-17", Statement = [{Resource = "arn:aws:s3:::bucket)"}]})}'
+        inner = TerraformParser._extract_jsonencode_inner("test", raw)
+        # The inner content must include the full string value with )
+        assert "bucket)" in inner
+        # Must end with the closing brace, not the ) inside the string
+        assert inner.endswith("}")
+
+    def test_jsonencode_inner_extraction_unterminated_raises(self, parser):
+        """Unterminated jsonencode must raise ValueError."""
+        raw = '${jsonencode({Version = "x"'
+        with pytest.raises(ValueError, match="unterminated jsonencode"):
+            TerraformParser._extract_jsonencode_inner("test", raw)
+
     def test_aws_iam_policy_dict_no_statement_fails_closed(self, parser):
         """Dict policy without Statement key must fail-closed (Issue #9)."""
         with pytest.raises(ValueError, match="no 'Statement' key"):

--- a/tests/test_terraform_parser.py
+++ b/tests/test_terraform_parser.py
@@ -360,6 +360,37 @@ class TestNormalizeResource:
         inner = TerraformParser._extract_jsonencode_inner("test", raw)
         assert "hello)" in inner
 
+    def test_hcl_map_to_json_single_quoted_equals(self, parser):
+        """_hcl_map_to_json must handle = inside single-quoted strings (Sentry HIGH)."""
+        hcl_content = "{Tag = 'key=value'}"
+        result = TerraformParser._hcl_map_to_json(hcl_content)
+        assert "key=value" in result
+        assert '"Tag":' in result
+
+    def test_hcl_map_to_json_double_equals_not_assignment(self, parser):
+        """_hcl_map_to_json must not treat == as key-value assignment (Sentry HIGH)."""
+        hcl_content = "{a == b}"
+        result = TerraformParser._hcl_map_to_json(hcl_content)
+        # == should NOT be converted to a key-value pair
+        assert '"a":' not in result
+        assert "==" in result
+
+    @patch('qwed_infra.parsers.terraform_parser.hcl2.load')
+    def test_non_list_top_level_block_handled(self, mock_hcl2_load, parser, tmp_path):
+        """variable/locals blocks (dicts, not lists) must not crash (Sentry CRITICAL)."""
+        tf_file = tmp_path / "test.tf"
+        tf_file.write_text("")
+
+        mock_hcl2_load.return_value = {
+            "variable": {"instance_type": {"type": "string"}},
+            "locals": {"default_type": "t3.micro"},
+            "resource": [{"aws_instance": {"web": {"instance_type": "t3.micro"}}}],
+        }
+
+        resources = parser.parse_directory(str(tmp_path))
+        assert len(resources["instances"]) == 1
+        assert resources["instances"][0]["instance_type"] == "t3.micro"
+
     def test_aws_iam_policy_dict_no_statement_fails_closed(self, parser):
         """Dict policy without Statement key must fail-closed (Issue #9)."""
         with pytest.raises(ValueError, match="no 'Statement' key"):

--- a/tests/test_terraform_parser.py
+++ b/tests/test_terraform_parser.py
@@ -332,6 +332,15 @@ class TestNormalizeResource:
         with pytest.raises(ValueError, match="unresolved interpolation"):
             parser._normalize_resource("aws_iam_policy", "unknown_interp", {"policy": policy_body})
 
+    def test_nested_brace_interpolation_rejected(self, parser):
+        """${merge({...}, var.x)} with colons inside nested braces must not bypass (Greptile P1)."""
+        policy_body = {
+            "Version": "2012-10-17",
+            "Statement": [{"Effect": "Allow", "Action": '${merge({"Action:": "s3:*"}, var.base)}', "Resource": "*"}]
+        }
+        with pytest.raises(ValueError, match="unresolved Terraform interpolation"):
+            parser._normalize_resource("aws_iam_policy", "nested_brace", {"policy": policy_body})
+
     def test_jsonencode_inner_extraction_with_paren_in_value(self, parser):
         """_extract_jsonencode_inner must handle ) inside string values (Sentry MEDIUM)."""
         raw = '${jsonencode({Version = "2012-10-17", Statement = [{Resource = "arn:aws:s3:::bucket)"}]})}'

--- a/tests/test_terraform_parser.py
+++ b/tests/test_terraform_parser.py
@@ -237,6 +237,37 @@ class TestNormalizeResource:
         with pytest.raises(ValueError, match="unresolved Terraform interpolation"):
             parser._normalize_resource("aws_iam_policy", "nested_interp", {"policy": policy_body})
 
+    def test_hcl_map_to_json_preserves_equals_in_strings(self, parser):
+        """_hcl_map_to_json must not corrupt = inside quoted string values (Sentry HIGH)."""
+        hcl_content = '{Version = "2012-10-17", Statement = [{Condition = {"StringEquals": {"aws:RequestTag/Team": "Team=backend"}}}]}'
+        result = TerraformParser._hcl_map_to_json(hcl_content)
+        # The value "Team=backend" must be preserved, not corrupted
+        assert "Team=backend" in result
+        # Keys must be quoted
+        assert '"Version":' in result
+        assert '"Statement":' in result
+        assert '"Condition":' in result
+
+    def test_hcl_map_to_json_basic_conversion(self, parser):
+        """_hcl_map_to_json converts unquoted keys and = to JSON syntax."""
+        hcl_content = '{Version = "2012-10-17", Action = "*"}'
+        result = TerraformParser._hcl_map_to_json(hcl_content)
+        parsed = json.loads(result)
+        assert parsed["Version"] == "2012-10-17"
+        assert parsed["Action"] == "*"
+
+    def test_normalize_hcl2_value_preserves_internal_quotes(self, parser):
+        """strip must use removeprefix/removesuffix, not strip (Sentry MEDIUM)."""
+        # A string like '"value"' should lose only the outer quotes
+        result = TerraformParser._normalize_hcl2_value('"test_value"')
+        assert result == "test_value"
+        # A string that doesn't start/end with quote should be unchanged
+        result = TerraformParser._normalize_hcl2_value('no_quotes')
+        assert result == "no_quotes"
+        # Only ONE pair of outer quotes removed, not all
+        result = TerraformParser._normalize_hcl2_value('""nested""')
+        assert result == '"nested"'
+
     def test_aws_iam_policy_dict_no_statement_fails_closed(self, parser):
         """Dict policy without Statement key must fail-closed (Issue #9)."""
         with pytest.raises(ValueError, match="no 'Statement' key"):

--- a/tests/test_terraform_parser.py
+++ b/tests/test_terraform_parser.py
@@ -350,6 +350,15 @@ class TestNormalizeResource:
         with pytest.raises(ValueError, match="unresolved interpolation"):
             parser._normalize_resource("aws_iam_policy", "for_expr", {"policy": policy_body})
 
+    def test_unterminated_interpolation_rejected(self, parser):
+        """Unterminated ${ without closing } must fail-closed, not silently pass (Greptile P1)."""
+        policy_body = {
+            "Version": "2012-10-17",
+            "Statement": [{"Effect": "Allow", "Action": "${*", "Resource": "*"}]
+        }
+        with pytest.raises(ValueError, match="unterminated interpolation"):
+            parser._normalize_resource("aws_iam_policy", "unterminated", {"policy": policy_body})
+
     @patch('qwed_infra.parsers.terraform_parser.hcl2.load')
     def test_parse_and_normalization_errors_aggregated(self, mock_hcl2_load, parser, tmp_path):
         """Both HCL parse errors and normalization errors in one ParseError (Sentry MEDIUM)."""


### PR DESCRIPTION
## Summary

Fixes two P0 issues in the Terraform parser — fail-open model integrity (#8) and IAM policy extraction stripping real policies into empty statements (#9). Also partially addresses #11 (removes implicit `instance_type` default).

## Changes

### #8 — Parser fail-closed
- Replaced `print + continue` with structured error collection
- Added `ParseError` exception carrying all collected errors
- If any `.tf` file fails to parse → `ParseError` (no partial model returned)
- If any resource fails to normalize → `ParseError`
- Downstream guards cannot run on untrustworthy partial output

### #9 — IAM policy extraction
- Implemented `jsonencode({...})` extraction (hcl2 parses as dict — handled directly)
- Implemented JSON string/heredoc extraction with `${...}` interpolation unwrapping
- Fail-closed on all unsupported forms:
  - Missing policy body
  - Empty string
  - Invalid JSON (e.g. `var.policy_json` interpolation)
  - Unsupported type (list, int, custom object)
  - Missing `Statement` key
- **Wildcard admin policies (`Action: *`, `Resource: *`) are never stripped to empty statements**

### #11 (partial) — Remove implicit instance_type default
- Missing `instance_type` now raises `ValueError` instead of defaulting to `t2.micro`
- Prevents unknown infrastructure from being mutated into a cheap default

## Tests — 14 new (89 total, up from 75)

| Test | Covers |
|------|--------|
| `test_parse_error_raises_parse_error` | Malformed .tf → ParseError |
| `test_one_bad_file_among_multiple_raises` | One bad file fails entire parse |
| `test_normalization_error_raises_parse_error` | Normalization failure → ParseError |
| `test_missing_instance_type_raises_parse_error` | Missing instance_type → fail-closed |
| `test_multiple_errors_all_collected` | All errors collected in one ParseError |
| `test_empty_directory_returns_empty_resources` | No .tf files → empty result (no raise) |
| `test_jsonencode_policy_extracted_end_to_end` | End-to-end jsonencode extraction |
| `test_aws_iam_policy_dict_body` | Dict policy (jsonencode) |
| `test_aws_iam_policy_json_string` | JSON string policy |
| `test_aws_iam_policy_heredoc_with_interpolation_wrapper` | `${...}` unwrapping |
| `test_aws_iam_policy_wildcard_admin_not_stripped` | Critical: admin policy not emptied |
| `test_aws_iam_policy_no_policy_body_fails_closed` | Missing body → fail-closed |
| `test_aws_iam_policy_invalid_json_fails_closed` | Variable interpolation → fail-closed |
| `test_aws_iam_policy_unsupported_type_fails_closed` | Unsupported type → fail-closed |

## Breaking changes

**Yes** — `parse_directory()` now raises `ParseError` instead of returning a partial model on failure. Callers must handle the exception:

```python
from qwed_infra.parsers.terraform_parser import TerraformParser, ParseError

try:
    resources = parser.parse_directory("./terraform")
except ParseError as e:
    print(f"Cannot verify — parse failed: {e.errors}")
    sys.exit(1)
```

This is intentional — the old behavior (return partial model → downstream guards produce false-safe verification) was the security bug.

## Related
- #8 — parser fail-closed (closed by this PR)
- #9 — IAM empty statements (closed by this PR)
- #11 — CostGuard defaults (partially addressed: instance_type default removed)
- #7 — fail-closed tracker (umbrella)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Terraform parsing is now fail-closed: if any `.tf` file fails to parse or normalize, the entire directory fails.
  * Errors are aggregated so you see a complete list of configuration issues in one run.
  * Invalid/missing required values (for example, `aws_instance` without an `instance_type`) are rejected instead of defaulting or partially continuing.

* **New Features**
  * IAM policy documents are extracted and validated across more input formats, including `jsonencode(...)` and JSON/heredoc variants.

* **Tests**
  * Expanded coverage for fail-closed behavior and stricter IAM policy handling.

* **Chores**
  * Demo now reports failures with an explicit summary instead of crashing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->