### PR TITLE
fix: remove fail-open patterns from CI workflows (#10)

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -35,10 +35,16 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" || pip install -e . || true
+          pip install -e ".[dev]"
+
+      - name: Check Snyk token
+        id: snyk_token_check
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: echo "configured=${{ env.SNYK_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
 
       - name: Snyk Python dependency scan
-        continue-on-error: true
+        if: steps.snyk_token_check.outputs.configured == 'true'
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: snyk test --org=${{ secrets.SNYK_ORG_ID }} --severity-threshold=high --sarif-file-output=snyk-python.sarif
@@ -58,8 +64,14 @@ jobs:
       - name: Install Snyk CLI
         run: npm install -g snyk
 
+      - name: Check Snyk token
+        id: snyk_token_check
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: echo "configured=${{ env.SNYK_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
+
       - name: Snyk IaC Terraform scan
-        continue-on-error: true
+        if: steps.snyk_token_check.outputs.configured == 'true'
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: snyk iac test demo/ --org=${{ secrets.SNYK_ORG_ID }} --severity-threshold=high --sarif-file-output=snyk-iac.sarif
@@ -79,8 +91,14 @@ jobs:
       - name: Install Snyk CLI
         run: npm install -g snyk
 
+      - name: Check Snyk token
+        id: snyk_token_check
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: echo "configured=${{ env.SNYK_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
+
       - name: Snyk Code analysis
-        continue-on-error: true
+        if: steps.snyk_token_check.outputs.configured == 'true'
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: snyk code test --org=${{ secrets.SNYK_ORG_ID }} --sarif-file-output=snyk-code.sarif

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -37,14 +37,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
-      - name: Check Snyk token
-        id: snyk_token_check
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        run: echo "configured=${{ env.SNYK_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
-
       - name: Snyk Python dependency scan
-        if: steps.snyk_token_check.outputs.configured == 'true'
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: snyk test --org=${{ secrets.SNYK_ORG_ID }} --severity-threshold=high --sarif-file-output=snyk-python.sarif
@@ -64,14 +57,7 @@ jobs:
       - name: Install Snyk CLI
         run: npm install -g snyk
 
-      - name: Check Snyk token
-        id: snyk_token_check
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        run: echo "configured=${{ env.SNYK_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
-
       - name: Snyk IaC Terraform scan
-        if: steps.snyk_token_check.outputs.configured == 'true'
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: snyk iac test demo/ --org=${{ secrets.SNYK_ORG_ID }} --severity-threshold=high --sarif-file-output=snyk-iac.sarif
@@ -91,14 +77,7 @@ jobs:
       - name: Install Snyk CLI
         run: npm install -g snyk
 
-      - name: Check Snyk token
-        id: snyk_token_check
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        run: echo "configured=${{ env.SNYK_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
-
       - name: Snyk Code analysis
-        if: steps.snyk_token_check.outputs.configured == 'true'
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: snyk code test --org=${{ secrets.SNYK_ORG_ID }} --sarif-file-output=snyk-code.sarif

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -29,11 +29,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest pytest-cov
-          pip install -e . || true
+          pip install -e .
 
       - name: Run tests with coverage
         run: |
-          pytest --cov=qwed_infra --cov-report=xml --cov-report=term-missing tests/ || true
+          pytest --cov=qwed_infra --cov-report=xml --cov-report=term-missing tests/
 
       - name: Check Sonar token
         id: sonar_token_check


### PR DESCRIPTION
**Description:**

Removes all `|| true` and `continue-on-error: true` patterns from CI workflows that caused fail-open pipeline behavior.

**snyk.yml:**
- Remove `|| true` from `pip install -e ".[dev]"` step
- Remove `continue-on-error: true` from Python, IaC, and Code scan jobs
- Add Snyk token check per job — scan is skipped gracefully when token unavailable (forks), but fails closed when token IS present and scan fails

**sonar.yml:**
- Remove `|| true` from `pip install -e .` step
- Remove `|| true` from `pytest --cov=...` step

**Verification:** Zero remaining `|| true` or `continue-on-error: true` across all `.github/` workflows.

Closes #10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened automated security and quality checks so failed scans and test runs now correctly fail the workflow instead of being ignored.
  * Improved dependency setup during CI runs by using a more consistent editable install process.

* **Chores**
  * Updated build and verification steps in the project’s automation to better surface issues early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->