### PR TITLE
fix: remove || true and continue-on-error from CI workflows (#10)

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -35,10 +35,9 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]" || pip install -e . || true
+          pip install -e ".[dev]"
 
       - name: Snyk Python dependency scan
-        continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: snyk test --org=${{ secrets.SNYK_ORG_ID }} --severity-threshold=high --sarif-file-output=snyk-python.sarif
@@ -59,7 +58,6 @@ jobs:
         run: npm install -g snyk
 
       - name: Snyk IaC Terraform scan
-        continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: snyk iac test demo/ --org=${{ secrets.SNYK_ORG_ID }} --severity-threshold=high --sarif-file-output=snyk-iac.sarif
@@ -80,7 +78,6 @@ jobs:
         run: npm install -g snyk
 
       - name: Snyk Code analysis
-        continue-on-error: true
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: snyk code test --org=${{ secrets.SNYK_ORG_ID }} --sarif-file-output=snyk-code.sarif

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          pip install -e ".[dev]" || pip install -e .
 
       - name: Snyk Python dependency scan
         env:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -36,6 +36,7 @@ jobs:
           pytest --cov=qwed_infra --cov-report=xml --cov-report=term-missing tests/
 
       - name: Check Sonar token
+        if: always()
         id: sonar_token_check
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -29,11 +29,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest pytest-cov
-          pip install -e . || true
+          pip install -e .
 
       - name: Run tests with coverage
         run: |
-          pytest --cov=qwed_infra --cov-report=xml --cov-report=term-missing tests/ || true
+          pytest --cov=qwed_infra --cov-report=xml --cov-report=term-missing tests/
 
       - name: Check Sonar token
         id: sonar_token_check

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -47,7 +47,7 @@ jobs:
           test "${{ steps.sonar_token_check.outputs.configured }}" = "true"
 
       - name: SonarCloud Scan
-        if: steps.sonar_token_check.outputs.configured == 'true'
+        if: always() && steps.sonar_token_check.outputs.configured == 'true'
         uses: SonarSource/sonarqube-scan-action@bfd4e558cda28cda6b5defafb9232d191be8c203 # v4.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Description:**

Removes fail-open patterns from CI workflows.

**`.github/workflows/snyk.yml`**
- Remove `|| true` from `pip install -e ".[dev]"`
- Remove `continue-on-error: true` from Python, IaC, and Code scan jobs

**`.github/workflows/sonar.yml`**
- Remove `|| true` from `pip install -e .`
- Remove `|| true` from `pytest --cov=...`

Closes #10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI checks now fail when dependency scans or code quality scans encounter errors, making build results more reliable.
  * Python dependency setup and test execution were streamlined to stop ignoring failures, so issues are surfaced earlier during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->