### PR TITLE
fix: add --all-projects to Snyk Python scan for pyproject.toml detection

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -36,11 +36,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]" || pip install -e .
+          pip freeze > requirements.txt
 
       - name: Snyk Python dependency scan
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        run: snyk test --file=pyproject.toml --package-manager=pip --org=${{ secrets.SNYK_ORG_ID }} --severity-threshold=high --sarif-file-output=snyk-python.sarif
+        run: snyk test --file=requirements.txt --package-manager=pip --org=${{ secrets.SNYK_ORG_ID }} --severity-threshold=high --sarif-file-output=snyk-python.sarif
 
       - name: Upload Snyk Python results to GitHub Security
         uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Snyk Python dependency scan
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        run: snyk test --all-projects --org=${{ secrets.SNYK_ORG_ID }} --severity-threshold=high --sarif-file-output=snyk-python.sarif
+        run: snyk test --file=pyproject.toml --package-manager=pip --org=${{ secrets.SNYK_ORG_ID }} --severity-threshold=high --sarif-file-output=snyk-python.sarif
 
       - name: Upload Snyk Python results to GitHub Security
         uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Snyk Python dependency scan
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        run: snyk test --org=${{ secrets.SNYK_ORG_ID }} --severity-threshold=high --sarif-file-output=snyk-python.sarif
+        run: snyk test --all-projects --org=${{ secrets.SNYK_ORG_ID }} --severity-threshold=high --sarif-file-output=snyk-python.sarif
 
       - name: Upload Snyk Python results to GitHub Security
         uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4


### PR DESCRIPTION
**Description:** Snyk's default `snyk test` doesn't detect `pyproject.toml` as a Python manifest. `--all-projects` enables detection of all project types including pip/pyproject.toml. One-line change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the automated security dependency scan for Python to use the repository’s `pyproject.toml` and the `pip` package manager.
  * Preserved the existing scan behavior, including the high-severity threshold and SARIF report output format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->