### PR TITLE
feat: port audit.py + InfraDiagnosticResult 3-layer model from qwed-tax v0.2.0 (#19)

### DIFF
--- a/qwed_infra/audit.py
+++ b/qwed_infra/audit.py
@@ -1,0 +1,139 @@
+"""
+Structured audit trace for guard verdicts.
+
+Provides canonical rule references and trace-building utilities
+so that all guards produce machine-readable audit trails instead
+of free-text reason strings.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass(frozen=True)
+class RuleRef:
+    """A canonical, immutable (rule_id, statute, jurisdiction) reference."""
+
+    rule_id: str
+    statute: str
+    jurisdiction: str = "GENERIC"
+
+
+# --- Infrastructure Rule References ---------------------------------------
+
+# IAM Guard
+IAM_DENY_PRECEDENCE = RuleRef(
+    "IAM_DENY_PRECEDENCE",
+    "AWS IAM Evaluation Logic (deny precedence)",
+)
+IAM_WILDCARD_MATCH = RuleRef(
+    "IAM_WILDCARD_MATCH",
+    "AWS IAM Action/Resource Wildcard Matching",
+)
+IAM_IP_CONDITION = RuleRef(
+    "IAM_IP_CONDITION",
+    "AWS IAM Condition Keys (aws:SourceIp)",
+)
+IAM_DATE_CONDITION = RuleRef(
+    "IAM_DATE_CONDITION",
+    "AWS IAM Condition Keys (aws:CurrentTime)",
+)
+IAM_STRING_CONDITION = RuleRef(
+    "IAM_STRING_CONDITION",
+    "AWS IAM Condition Keys (StringEquals / StringLike)",
+)
+IAM_UNKNOWN_OPERATOR = RuleRef(
+    "IAM_UNKNOWN_OPERATOR",
+    "AWS IAM Condition Operators (unknown operator — fail closed)",
+)
+
+# Network Guard
+NETWORK_SG_INGRESS = RuleRef(
+    "NETWORK_SG_INGRESS",
+    "AWS Security Group Ingress Rules",
+)
+NETWORK_REACHABILITY = RuleRef(
+    "NETWORK_REACHABILITY",
+    "AWS VPC Routing + SG Evaluation",
+)
+NETWORK_NO_ROUTE = RuleRef(
+    "NETWORK_NO_ROUTE",
+    "AWS VPC Routing (no path between nodes)",
+)
+NETWORK_INVALID_INTERNAL = RuleRef(
+    "NETWORK_INVALID_INTERNAL",
+    "AWS VPC (invalid internal source IP)",
+)
+NETWORK_UNKNOWN_DEST = RuleRef(
+    "NETWORK_UNKNOWN_DEST",
+    "AWS VPC (destination subnet not found)",
+)
+
+# Cost Guard
+COST_BUDGET_EXCEEDED = RuleRef(
+    "COST_BUDGET_EXCEEDED",
+    "AWS Pricing + Budget Policy",
+)
+COST_UNKNOWN_RESOURCE = RuleRef(
+    "COST_UNKNOWN_RESOURCE",
+    "AWS Pricing Catalog (unknown instance type)",
+)
+COST_WITHIN_BUDGET = RuleRef(
+    "COST_WITHIN_BUDGET",
+    "AWS Pricing + Budget Policy (within budget)",
+)
+
+
+def build_trace(
+    rule: RuleRef,
+    outcome: str,
+    inputs: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """
+    Build a structured audit-trace entry for a guard verdict.
+    """
+    return {
+        "rule_id": rule.rule_id,
+        "statute": rule.statute,
+        "jurisdiction": rule.jurisdiction,
+        "outcome": outcome,
+        "inputs": copy.deepcopy(inputs) if inputs else {},
+    }
+
+
+def trace_proof_ref(trace: Dict[str, Any]) -> str:
+    """Compute a deterministic SHA-256 proof reference from an audit trace."""
+    try:
+        payload = json.dumps(trace, sort_keys=True)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Audit trace must be JSON-serializable for proof_ref hashing: {exc}"
+        ) from exc
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+__all__ = [
+    "RuleRef",
+    "build_trace",
+    "trace_proof_ref",
+    "IAM_DENY_PRECEDENCE",
+    "IAM_WILDCARD_MATCH",
+    "IAM_IP_CONDITION",
+    "IAM_DATE_CONDITION",
+    "IAM_STRING_CONDITION",
+    "IAM_UNKNOWN_OPERATOR",
+    "NETWORK_SG_INGRESS",
+    "NETWORK_REACHABILITY",
+    "NETWORK_NO_ROUTE",
+    "NETWORK_INVALID_INTERNAL",
+    "NETWORK_UNKNOWN_DEST",
+    "COST_BUDGET_EXCEEDED",
+    "COST_UNKNOWN_RESOURCE",
+    "COST_WITHIN_BUDGET",
+]

--- a/qwed_infra/audit.py
+++ b/qwed_infra/audit.py
@@ -109,7 +109,7 @@ def build_trace(
 def trace_proof_ref(trace: Dict[str, Any]) -> str:
     """Compute a deterministic SHA-256 proof reference from an audit trace."""
     try:
-        payload = json.dumps(trace, sort_keys=True)
+        payload = json.dumps(trace, sort_keys=True, allow_nan=False)
     except (TypeError, ValueError) as exc:
         raise ValueError(
             f"Audit trace must be JSON-serializable for proof_ref hashing: {exc}"

--- a/qwed_infra/diagnostics.py
+++ b/qwed_infra/diagnostics.py
@@ -198,7 +198,9 @@ class InfraDiagnosticResult:
                     f"from_dict: invalid status {raw_status!r} — "
                     f"must be one of: {valid}."
                 ) from None
-        elif not isinstance(raw_status, InfraDiagnosticStatus):
+        elif isinstance(raw_status, InfraDiagnosticStatus):
+            status = raw_status
+        else:
             valid = ", ".join(s.value for s in InfraDiagnosticStatus)
             raise ValueError(
                 f"from_dict: invalid status type {type(raw_status).__name__} — "

--- a/qwed_infra/diagnostics.py
+++ b/qwed_infra/diagnostics.py
@@ -76,7 +76,7 @@ class InfraAdvisoryCheck:
 def compute_proof_ref(evidence: Dict[str, Any]) -> str:
     """Compute a deterministic proof reference hash from retained evidence."""
     try:
-        payload = json.dumps(evidence, sort_keys=True)
+        payload = json.dumps(evidence, sort_keys=True, allow_nan=False)
     except (TypeError, ValueError) as exc:
         raise ValueError(
             f"Proof evidence must be JSON-serializable for proof_ref hashing: {exc}"
@@ -113,12 +113,18 @@ class InfraDiagnosticResult:
         if not isinstance(self.developer_fields, dict):
             raise ValueError("developer_fields must be a dict")
 
-        if self.status is InfraDiagnosticStatus.VERIFIED and not self.proof_ref:
-            raise ValueError(
-                "VERIFIED status requires proof_ref is not None and non-empty — "
-                "a claim cannot be marked proven without a proof artifact hash. "
-                "Use UNVERIFIABLE if no proof was established."
-            )
+        if self.status is InfraDiagnosticStatus.VERIFIED:
+            if not self.proof_ref:
+                raise ValueError(
+                    "VERIFIED status requires proof_ref is not None and non-empty — "
+                    "a claim cannot be marked proven without a proof artifact hash. "
+                    "Use UNVERIFIABLE if no proof was established."
+                )
+            if "audit_trace" not in self.developer_fields:
+                raise ValueError(
+                    "VERIFIED status requires 'audit_trace' in developer_fields — "
+                    "a proved claim must reference its audit trace."
+                )
 
         if self.status is not InfraDiagnosticStatus.VERIFIED and self.proof_ref is not None:
             raise ValueError(
@@ -180,20 +186,22 @@ class InfraDiagnosticResult:
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "InfraDiagnosticResult":
-        status = data.get("status", "UNVERIFIABLE")
-        if isinstance(status, str):
+        raw_status = data.get("status")
+        if raw_status is None:
+            raise ValueError("from_dict: 'status' is required — no default.")
+        if isinstance(raw_status, str):
             try:
-                status = InfraDiagnosticStatus(status)
+                status = InfraDiagnosticStatus(raw_status)
             except ValueError:
                 valid = ", ".join(s.value for s in InfraDiagnosticStatus)
                 raise ValueError(
-                    f"from_dict: invalid status {status!r} — "
+                    f"from_dict: invalid status {raw_status!r} — "
                     f"must be one of: {valid}."
                 ) from None
-        elif not isinstance(status, InfraDiagnosticStatus):
+        elif not isinstance(raw_status, InfraDiagnosticStatus):
             valid = ", ".join(s.value for s in InfraDiagnosticStatus)
             raise ValueError(
-                f"from_dict: invalid status type {type(status).__name__} — "
+                f"from_dict: invalid status type {type(raw_status).__name__} — "
                 f"must be one of: {valid}."
             )
 

--- a/qwed_infra/diagnostics.py
+++ b/qwed_infra/diagnostics.py
@@ -1,0 +1,264 @@
+"""
+QWED-Infra Structured Verification Diagnostics.
+
+Implements the same 3-layer model as QWED-Tax TaxDiagnosticResult
+but as an independent package with infrastructure-specific fields.
+
+    Layer 1 — Agent-Safe Diagnostics
+        agent_message: str
+    Layer 2 — Developer Diagnostics
+        developer_fields: dict
+    Layer 3 — Proof Diagnostics
+        proof_ref: Optional[str]
+
+This module does NOT depend on qwed-tax. The model follows the same
+3-layer pattern using infra-specific developer_fields.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+class InfraDiagnosticStatus(str, Enum):
+    """Infrastructure verification diagnostic status (3 states only)."""
+    VERIFIED = "VERIFIED"
+    UNVERIFIABLE = "UNVERIFIABLE"
+    BLOCKED = "BLOCKED"
+
+
+@dataclass(frozen=True)
+class InfraAdvisoryCheck:
+    """A non-proof-bearing analysis result attached as advisory metadata."""
+    name: str
+    advisory_only: bool = True
+    constraint_id: Optional[str] = None
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.advisory_only is not True:
+            raise ValueError(
+                "InfraAdvisoryCheck.advisory_only must be True — "
+                "advisory checks must never influence the verification verdict."
+            )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "advisory_only": self.advisory_only,
+            "constraint_id": self.constraint_id,
+            "details": self.details,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "InfraAdvisoryCheck":
+        raw_advisory_only = data.get("advisory_only", True)
+        if isinstance(raw_advisory_only, bool):
+            advisory_only = raw_advisory_only
+        elif isinstance(raw_advisory_only, int) and raw_advisory_only in (0, 1):
+            advisory_only = bool(raw_advisory_only)
+        else:
+            raise ValueError(
+                "InfraAdvisoryCheck.advisory_only must be a bool or integer 0/1"
+            )
+        return cls(
+            name=data.get("name", ""),
+            advisory_only=advisory_only,
+            constraint_id=data.get("constraint_id"),
+            details=data.get("details", {}),
+        )
+
+
+def compute_proof_ref(evidence: Dict[str, Any]) -> str:
+    """Compute a deterministic proof reference hash from retained evidence."""
+    try:
+        payload = json.dumps(evidence, sort_keys=True)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Proof evidence must be JSON-serializable for proof_ref hashing: {exc}"
+        ) from exc
+    digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    return f"sha256:{digest}"
+
+
+@dataclass(frozen=True)
+class InfraDiagnosticResult:
+    """Unified 3-layer infra verification diagnostic result.
+
+    Authority contract:
+        proof_ref is not None → authoritative, admissible for control flow
+        proof_ref is None     → non-authoritative, NOT admissible for control flow
+    """
+
+    status: InfraDiagnosticStatus
+    agent_message: str
+    developer_fields: Dict[str, Any] = field(default_factory=dict)
+    proof_ref: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.status, InfraDiagnosticStatus):
+            valid = ", ".join(s.value for s in InfraDiagnosticStatus)
+            raise ValueError(f"status must be an InfraDiagnosticStatus ({valid})")
+
+        if not isinstance(self.agent_message, str) or not self.agent_message.strip():
+            raise ValueError(
+                "agent_message must be a non-empty string — "
+                "Layer 1 diagnostics are mandatory"
+            )
+
+        if not isinstance(self.developer_fields, dict):
+            raise ValueError("developer_fields must be a dict")
+
+        if self.status is InfraDiagnosticStatus.VERIFIED and not self.proof_ref:
+            raise ValueError(
+                "VERIFIED status requires proof_ref is not None and non-empty — "
+                "a claim cannot be marked proven without a proof artifact hash. "
+                "Use UNVERIFIABLE if no proof was established."
+            )
+
+        if self.status is not InfraDiagnosticStatus.VERIFIED and self.proof_ref is not None:
+            raise ValueError(
+                f"{self.status.value} status requires proof_ref is None — "
+                "non-VERIFIED states are non-authoritative by construction."
+            )
+
+    @property
+    def is_verified(self) -> bool:
+        return self.status is InfraDiagnosticStatus.VERIFIED
+
+    @property
+    def is_authoritative(self) -> bool:
+        return self.proof_ref is not None
+
+    @property
+    def is_fail_closed(self) -> bool:
+        return self.status in (InfraDiagnosticStatus.UNVERIFIABLE, InfraDiagnosticStatus.BLOCKED)
+
+    @property
+    def constraint_id(self) -> Optional[str]:
+        return self.developer_fields.get("constraint_id")
+
+    @property
+    def audit_trace(self) -> Optional[Dict[str, Any]]:
+        return self.developer_fields.get("audit_trace")
+
+    @property
+    def advisory_checks(self) -> List[InfraAdvisoryCheck]:
+        raw = self.developer_fields.get("advisory_checks", [])
+        if not isinstance(raw, list):
+            return []
+        result = []
+        for item in raw:
+            if isinstance(item, dict):
+                try:
+                    result.append(InfraAdvisoryCheck.from_dict(item))
+                except ValueError:
+                    continue
+            elif isinstance(item, InfraAdvisoryCheck):
+                result.append(item)
+        return result
+
+    def to_dict(self) -> Dict[str, Any]:
+        fields = dict(self.developer_fields)
+        checks = fields.get("advisory_checks")
+        if isinstance(checks, list):
+            fields["advisory_checks"] = [
+                item.to_dict() if isinstance(item, InfraAdvisoryCheck) else item
+                for item in checks
+            ]
+        return {
+            "status": self.status.value,
+            "agent_message": self.agent_message,
+            "developer_fields": fields,
+            "proof_ref": self.proof_ref,
+            "is_authoritative": self.is_authoritative,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "InfraDiagnosticResult":
+        status = data.get("status", "UNVERIFIABLE")
+        if isinstance(status, str):
+            try:
+                status = InfraDiagnosticStatus(status)
+            except ValueError:
+                valid = ", ".join(s.value for s in InfraDiagnosticStatus)
+                raise ValueError(
+                    f"from_dict: invalid status {status!r} — "
+                    f"must be one of: {valid}."
+                ) from None
+        elif not isinstance(status, InfraDiagnosticStatus):
+            valid = ", ".join(s.value for s in InfraDiagnosticStatus)
+            raise ValueError(
+                f"from_dict: invalid status type {type(status).__name__} — "
+                f"must be one of: {valid}."
+            )
+
+        agent_message = data.get("agent_message")
+        if not isinstance(agent_message, str) or not agent_message.strip():
+            raise ValueError(
+                "from_dict: 'agent_message' is missing or empty — "
+                "Layer 1 diagnostics are mandatory."
+            )
+
+        developer_fields = data.get("developer_fields", {})
+        if not isinstance(developer_fields, dict):
+            raise ValueError("from_dict: 'developer_fields' must be a dict.")
+
+        return cls(
+            status=status,
+            agent_message=agent_message,
+            developer_fields=developer_fields,
+            proof_ref=data.get("proof_ref"),
+        )
+
+    @classmethod
+    def verified(
+        cls,
+        agent_message: str,
+        developer_fields: Dict[str, Any],
+        evidence: Dict[str, Any],
+    ) -> "InfraDiagnosticResult":
+        return cls(
+            status=InfraDiagnosticStatus.VERIFIED,
+            agent_message=agent_message,
+            developer_fields=developer_fields,
+            proof_ref=compute_proof_ref(evidence),
+        )
+
+    @classmethod
+    def unverifiable(
+        cls,
+        agent_message: str,
+        developer_fields: Optional[Dict[str, Any]] = None,
+    ) -> "InfraDiagnosticResult":
+        return cls(
+            status=InfraDiagnosticStatus.UNVERIFIABLE,
+            agent_message=agent_message,
+            developer_fields=developer_fields or {},
+            proof_ref=None,
+        )
+
+    @classmethod
+    def blocked(
+        cls,
+        agent_message: str,
+        developer_fields: Optional[Dict[str, Any]] = None,
+    ) -> "InfraDiagnosticResult":
+        return cls(
+            status=InfraDiagnosticStatus.BLOCKED,
+            agent_message=agent_message,
+            developer_fields=developer_fields or {},
+            proof_ref=None,
+        )
+
+
+__all__ = [
+    "InfraDiagnosticStatus",
+    "InfraDiagnosticResult",
+    "InfraAdvisoryCheck",
+    "compute_proof_ref",
+]

--- a/qwed_infra/guards/cost_guard.py
+++ b/qwed_infra/guards/cost_guard.py
@@ -116,7 +116,7 @@ class CostGuard:
 
         if not result.within_budget:
             trace = build_trace(COST_BUDGET_EXCEEDED, "EXCEEDED")
-            return InfraDiagnosticResult.verified(
+            return InfraDiagnosticResult.blocked(
                 agent_message="Cost estimate exceeds budget",
                 developer_fields={
                     "constraint_id": _COST_CONSTRAINT_ID,
@@ -126,7 +126,6 @@ class CostGuard:
                     "reason": result.reason,
                     "audit_trace": trace,
                 },
-                evidence={**trace, "total_monthly_cost": result.total_monthly_cost, "budget": result.budget},
             )
 
         trace = build_trace(COST_WITHIN_BUDGET, "ALLOWED")

--- a/qwed_infra/guards/cost_guard.py
+++ b/qwed_infra/guards/cost_guard.py
@@ -1,7 +1,17 @@
-from typing import Dict, Any
+from typing import Any, Dict, List, Optional
+
 from pydantic import BaseModel
 
+from qwed_infra.audit import (
+    COST_BUDGET_EXCEEDED,
+    COST_UNKNOWN_RESOURCE,
+    COST_WITHIN_BUDGET,
+    build_trace,
+)
+from qwed_infra.diagnostics import InfraDiagnosticResult
+
 class CostEstimate(BaseModel):
+    model_config = {"extra": "forbid"}
     total_monthly_cost: float
     currency: str = "USD"
     breakdown: Dict[str, float]
@@ -95,4 +105,52 @@ class CostGuard:
             within_budget=within_budget,
             budget=budget_monthly,
             reason=reason
+        )
+
+    @staticmethod
+    def to_diagnostic(result: CostEstimate) -> InfraDiagnosticResult:
+        """Convert a CostEstimate to an InfraDiagnosticResult."""
+        has_unknown = "unknown instance types" in result.reason
+
+        if has_unknown:
+            trace = build_trace(COST_UNKNOWN_RESOURCE, "INCOMPLETE")
+            return InfraDiagnosticResult.blocked(
+                agent_message="Cost estimate incomplete — unknown resource types",
+                developer_fields={
+                    "constraint_id": "cost_guard.verify_budget",
+                    "within_budget": result.within_budget,
+                    "total_monthly_cost": result.total_monthly_cost,
+                    "budget": result.budget,
+                    "reason": result.reason,
+                    "audit_trace": trace,
+                },
+            )
+
+        if not result.within_budget:
+            trace = build_trace(COST_BUDGET_EXCEEDED, "EXCEEDED")
+            return InfraDiagnosticResult.verified(
+                agent_message="Cost budget verification completed",
+                developer_fields={
+                    "constraint_id": "cost_guard.verify_budget",
+                    "within_budget": result.within_budget,
+                    "total_monthly_cost": result.total_monthly_cost,
+                    "budget": result.budget,
+                    "reason": result.reason,
+                    "audit_trace": trace,
+                },
+                evidence={**trace, "total_monthly_cost": result.total_monthly_cost, "budget": result.budget},
+            )
+
+        trace = build_trace(COST_WITHIN_BUDGET, "ALLOWED")
+        return InfraDiagnosticResult.verified(
+            agent_message="Cost estimate within budget",
+            developer_fields={
+                "constraint_id": "cost_guard.verify_budget",
+                "within_budget": result.within_budget,
+                "total_monthly_cost": result.total_monthly_cost,
+                "budget": result.budget,
+                "reason": result.reason,
+                "audit_trace": trace,
+            },
+            evidence={**trace, "total_monthly_cost": result.total_monthly_cost, "budget": result.budget},
         )

--- a/qwed_infra/guards/cost_guard.py
+++ b/qwed_infra/guards/cost_guard.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict
 
 from pydantic import BaseModel
 
@@ -10,6 +10,9 @@ from qwed_infra.audit import (
 )
 from qwed_infra.diagnostics import InfraDiagnosticResult
 
+_COST_CONSTRAINT_ID = "cost_guard.verify_budget"
+
+
 class CostEstimate(BaseModel):
     model_config = {"extra": "forbid"}
     total_monthly_cost: float
@@ -18,6 +21,8 @@ class CostEstimate(BaseModel):
     within_budget: bool
     budget: float
     reason: str
+    has_unknown_types: bool = False
+
 
 class CostGuard:
     """
@@ -26,37 +31,26 @@ class CostGuard:
     """
     
     # Simplified Static Pricing Catalog (USD per hour)
-    # In production, this would fetch from AWS Price List API / Azure Retail Prices API
     PRICING_CATALOG = {
-        # Compute (AWS estimates)
         "t3.micro": 0.0104,
         "t3.small": 0.0208,
         "t3.medium": 0.0416,
         "m5.large": 0.096,
         "c5.large": 0.085,
-        "g4dn.xlarge": 0.526,   # GPU
-        "p4d.24xlarge": 32.77,  # Big GPU (The budget killer)
-        
-        # Database (RDS estimates)
+        "g4dn.xlarge": 0.526,
+        "p4d.24xlarge": 32.77,
         "db.t3.micro": 0.017,
         "db.m5.large": 0.142,
-        
-        # Storage (per GB per month, normalized to hourly for simplicity ~ 0.023 / 730)
-        "gp2-storage-gb": 0.0000315, 
+        "gp2-storage-gb": 0.0000315,
     }
     
     HOURS_PER_MONTH = 730
     
     def verify_budget(self, resources: Dict[str, Any], budget_monthly: float) -> CostEstimate:
-        """
-        Calculates total estimated monthly cost of the infrastructure and validates against budget.
-        """
         total_hourly_cost = 0.0
         breakdown = {}
         unknown_instance_types = []
 
-        # 1. Calculate Estimations
-        # Instances
         instances = resources.get("instances", [])
         for inst in instances:
             inst_type = inst.get("instance_type", "t3.micro")
@@ -71,9 +65,6 @@ class CostGuard:
             total_hourly_cost += cost
             breakdown[inst['id']] = cost * self.HOURS_PER_MONTH
 
-        # Storage
-        # Explicit volumes or implicit in instance?
-        # Let's support an explicit 'volumes' list
         volumes = resources.get("volumes", [])
         for vol in volumes:
             size_gb = vol.get("size_gb", 10)
@@ -83,12 +74,10 @@ class CostGuard:
             breakdown[f"vol-{vol.get('id', 'unknown')}"] = cost * self.HOURS_PER_MONTH
 
         total_monthly = total_hourly_cost * self.HOURS_PER_MONTH
-        
-        # 2. Check Budget
-        # Unknown instance types → fail closed (budget cannot be proved)
-        within_budget = (total_monthly <= budget_monthly) and not unknown_instance_types
+        has_unknown = bool(unknown_instance_types)
+        within_budget = (total_monthly <= budget_monthly) and not has_unknown
 
-        if unknown_instance_types:
+        if has_unknown:
             reason = (
                 f"Cost estimate incomplete — unknown instance types: "
                 f"{sorted(set(unknown_instance_types))}. "
@@ -98,30 +87,29 @@ class CostGuard:
             reason = f"Estimated cost ${total_monthly:.2f} is within budget ${budget_monthly:.2f}"
         else:
             reason = f"Estimated cost ${total_monthly:.2f} EXCEEDS budget ${budget_monthly:.2f}"
-            
+
         return CostEstimate(
             total_monthly_cost=total_monthly,
             breakdown=breakdown,
             within_budget=within_budget,
             budget=budget_monthly,
-            reason=reason
+            reason=reason,
+            has_unknown_types=has_unknown,
         )
 
     @staticmethod
     def to_diagnostic(result: CostEstimate) -> InfraDiagnosticResult:
-        """Convert a CostEstimate to an InfraDiagnosticResult."""
-        has_unknown = "unknown instance types" in result.reason
-
-        if has_unknown:
+        if result.has_unknown_types:
             trace = build_trace(COST_UNKNOWN_RESOURCE, "INCOMPLETE")
             return InfraDiagnosticResult.blocked(
                 agent_message="Cost estimate incomplete — unknown resource types",
                 developer_fields={
-                    "constraint_id": "cost_guard.verify_budget",
+                    "constraint_id": _COST_CONSTRAINT_ID,
                     "within_budget": result.within_budget,
                     "total_monthly_cost": result.total_monthly_cost,
                     "budget": result.budget,
                     "reason": result.reason,
+                    "has_unknown_types": result.has_unknown_types,
                     "audit_trace": trace,
                 },
             )
@@ -129,9 +117,9 @@ class CostGuard:
         if not result.within_budget:
             trace = build_trace(COST_BUDGET_EXCEEDED, "EXCEEDED")
             return InfraDiagnosticResult.verified(
-                agent_message="Cost budget verification completed",
+                agent_message="Cost estimate exceeds budget",
                 developer_fields={
-                    "constraint_id": "cost_guard.verify_budget",
+                    "constraint_id": _COST_CONSTRAINT_ID,
                     "within_budget": result.within_budget,
                     "total_monthly_cost": result.total_monthly_cost,
                     "budget": result.budget,
@@ -145,7 +133,7 @@ class CostGuard:
         return InfraDiagnosticResult.verified(
             agent_message="Cost estimate within budget",
             developer_fields={
-                "constraint_id": "cost_guard.verify_budget",
+                "constraint_id": _COST_CONSTRAINT_ID,
                 "within_budget": result.within_budget,
                 "total_monthly_cost": result.total_monthly_cost,
                 "budget": result.budget,

--- a/qwed_infra/guards/cost_guard.py
+++ b/qwed_infra/guards/cost_guard.py
@@ -99,6 +99,31 @@ class CostGuard:
 
     @staticmethod
     def to_diagnostic(result: CostEstimate) -> InfraDiagnosticResult:
+        expected_within_budget = (
+            result.total_monthly_cost <= result.budget
+            and not result.has_unknown_types
+        )
+        if result.within_budget != expected_within_budget:
+            trace_rule = (
+                COST_UNKNOWN_RESOURCE
+                if result.has_unknown_types
+                else COST_BUDGET_EXCEEDED
+            )
+            trace = build_trace(trace_rule, "INCONSISTENT")
+            return InfraDiagnosticResult.blocked(
+                agent_message="Cost estimate could not be verified",
+                developer_fields={
+                    "constraint_id": _COST_CONSTRAINT_ID,
+                    "within_budget": result.within_budget,
+                    "expected_within_budget": expected_within_budget,
+                    "total_monthly_cost": result.total_monthly_cost,
+                    "budget": result.budget,
+                    "reason": result.reason,
+                    "has_unknown_types": result.has_unknown_types,
+                    "audit_trace": trace,
+                },
+            )
+
         if result.has_unknown_types:
             trace = build_trace(COST_UNKNOWN_RESOURCE, "INCOMPLETE")
             return InfraDiagnosticResult.blocked(

--- a/qwed_infra/guards/iam_guard.py
+++ b/qwed_infra/guards/iam_guard.py
@@ -11,15 +11,12 @@ from pydantic import BaseModel
 from z3 import And, InRe, Not, Or, Solver, String, StringVal, sat
 
 from qwed_infra.audit import (
-    IAM_DATE_CONDITION,
     IAM_DENY_PRECEDENCE,
-    IAM_IP_CONDITION,
-    IAM_STRING_CONDITION,
-    IAM_UNKNOWN_OPERATOR,
-    IAM_WILDCARD_MATCH,
     build_trace,
 )
 from qwed_infra.diagnostics import InfraDiagnosticResult
+
+_IAM_CONSTRAINT_ID = "iam_guard.verify_access"
 
 
 class IamPolicy(BaseModel):
@@ -307,7 +304,7 @@ class IamGuard:
             return InfraDiagnosticResult.blocked(
                 agent_message="IAM policy verification could not be completed",
                 developer_fields={
-                    "constraint_id": "iam_guard.verify_access",
+                    "constraint_id": _IAM_CONSTRAINT_ID,
                     "error": result.error,
                     "audit_trace": audit_trace,
                 },
@@ -331,7 +328,7 @@ class IamGuard:
         return InfraDiagnosticResult.verified(
             agent_message="IAM policy access check completed",
             developer_fields={
-                "constraint_id": "iam_guard.verify_access",
+                "constraint_id": _IAM_CONSTRAINT_ID,
                 "allowed": result.allowed,
                 "proof": result.proof,
                 "audit_trace": trace,

--- a/qwed_infra/guards/iam_guard.py
+++ b/qwed_infra/guards/iam_guard.py
@@ -301,8 +301,8 @@ class IamGuard:
     ) -> InfraDiagnosticResult:
         """Convert a VerificationResult to an InfraDiagnosticResult."""
         if not result.verified:
-            trace = audit_trace if audit_trace is not None else build_trace(IAM_DENY_PRECEDENCE, "BLOCKED")
-            return InfraDiagnosticResult.blocked(
+            trace = audit_trace if audit_trace is not None else build_trace(IAM_DENY_PRECEDENCE, "UNVERIFIABLE")
+            return InfraDiagnosticResult.unverifiable(
                 agent_message="IAM policy verification could not be completed",
                 developer_fields={
                     "constraint_id": _IAM_CONSTRAINT_ID,

--- a/qwed_infra/guards/iam_guard.py
+++ b/qwed_infra/guards/iam_guard.py
@@ -301,12 +301,13 @@ class IamGuard:
     ) -> InfraDiagnosticResult:
         """Convert a VerificationResult to an InfraDiagnosticResult."""
         if not result.verified:
+            trace = audit_trace if audit_trace is not None else build_trace(IAM_DENY_PRECEDENCE, "BLOCKED")
             return InfraDiagnosticResult.blocked(
                 agent_message="IAM policy verification could not be completed",
                 developer_fields={
                     "constraint_id": _IAM_CONSTRAINT_ID,
                     "error": result.error,
-                    "audit_trace": audit_trace,
+                    "audit_trace": trace,
                 },
             )
 
@@ -316,7 +317,7 @@ class IamGuard:
         else:
             outcome = "DENIED"
 
-        trace = audit_trace or build_trace(rule, outcome)
+        trace = audit_trace if audit_trace is not None else build_trace(rule, outcome)
 
         evidence = {
             "verified": result.verified,

--- a/qwed_infra/guards/iam_guard.py
+++ b/qwed_infra/guards/iam_guard.py
@@ -326,8 +326,9 @@ class IamGuard:
             "audit_trace": trace,
         }
 
+        agent_msg = "IAM policy access: allowed" if result.allowed else "IAM policy access: denied"
         return InfraDiagnosticResult.verified(
-            agent_message="IAM policy access check completed",
+            agent_message=agent_msg,
             developer_fields={
                 "constraint_id": _IAM_CONSTRAINT_ID,
                 "allowed": result.allowed,

--- a/qwed_infra/guards/iam_guard.py
+++ b/qwed_infra/guards/iam_guard.py
@@ -10,13 +10,26 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel
 from z3 import And, InRe, Not, Or, Solver, String, StringVal, sat
 
+from qwed_infra.audit import (
+    IAM_DATE_CONDITION,
+    IAM_DENY_PRECEDENCE,
+    IAM_IP_CONDITION,
+    IAM_STRING_CONDITION,
+    IAM_UNKNOWN_OPERATOR,
+    IAM_WILDCARD_MATCH,
+    build_trace,
+)
+from qwed_infra.diagnostics import InfraDiagnosticResult
+
 
 class IamPolicy(BaseModel):
+    model_config = {"extra": "forbid"}
     Version: str
     Statement: List[Dict[str, Any]]
 
 
 class VerificationResult(BaseModel):
+    model_config = {"extra": "forbid"}
     verified: bool
     allowed: bool
     proof: Optional[str] = None
@@ -282,6 +295,48 @@ class IamGuard:
                 "aws:SourceIp": "0.0.0.0",
                 "aws:CurrentTime": "2100-01-01T00:00:00Z",
             },
+        )
+
+    @staticmethod
+    def to_diagnostic(
+        result: VerificationResult,
+        audit_trace: Optional[Dict[str, Any]] = None,
+    ) -> InfraDiagnosticResult:
+        """Convert a VerificationResult to an InfraDiagnosticResult."""
+        if not result.verified:
+            return InfraDiagnosticResult.blocked(
+                agent_message="IAM policy verification could not be completed",
+                developer_fields={
+                    "constraint_id": "iam_guard.verify_access",
+                    "error": result.error,
+                    "audit_trace": audit_trace,
+                },
+            )
+
+        rule = IAM_DENY_PRECEDENCE
+        if result.allowed:
+            outcome = "ALLOWED"
+        else:
+            outcome = "DENIED"
+
+        trace = audit_trace or build_trace(rule, outcome)
+
+        evidence = {
+            "verified": result.verified,
+            "allowed": result.allowed,
+            "proof": result.proof,
+            "audit_trace": trace,
+        }
+
+        return InfraDiagnosticResult.verified(
+            agent_message="IAM policy access check completed",
+            developer_fields={
+                "constraint_id": "iam_guard.verify_access",
+                "allowed": result.allowed,
+                "proof": result.proof,
+                "audit_trace": trace,
+            },
+            evidence=evidence,
         )
 
 

--- a/qwed_infra/guards/network_guard.py
+++ b/qwed_infra/guards/network_guard.py
@@ -97,12 +97,13 @@ class NetworkGuard:
             except (nx.NetworkXNoPath, nx.NodeNotFound):
                 return ComputedPath(reachable=False, path=[], reason="No Route exists between nodes", port=port, failure_code="no_route")
         else:
-            # Internal source — verify source is a valid IP address
+            # Internal source — verify source is a valid private IP address
             try:
-                ipaddress.ip_address(source)
+                addr = ipaddress.ip_address(source)
             except ValueError:
                 return ComputedPath(reachable=False, path=[], reason=f"Invalid internal source: '{source}'", port=port, failure_code="invalid_internal_source")
-            # Verify destination subnet exists in infra
+            if not addr.is_private:
+                return ComputedPath(reachable=False, path=[], reason=f"Internal source '{source}' is not a private IP", port=port, failure_code="invalid_internal_source")
             dest_exists = any(s["id"] == destination for s in resources.get("subnets", []))
             if not dest_exists:
                 return ComputedPath(reachable=False, path=[], reason=f"Destination '{destination}' not found in subnets", port=port, failure_code="unknown_destination")

--- a/qwed_infra/guards/network_guard.py
+++ b/qwed_infra/guards/network_guard.py
@@ -3,17 +3,30 @@ import ipaddress
 import networkx as nx
 from pydantic import BaseModel
 
+from qwed_infra.audit import (
+    NETWORK_INVALID_INTERNAL,
+    NETWORK_NO_ROUTE,
+    NETWORK_REACHABILITY,
+    NETWORK_SG_INGRESS,
+    NETWORK_UNKNOWN_DEST,
+    build_trace,
+)
+from qwed_infra.diagnostics import InfraDiagnosticResult
+
 class NetworkNode(BaseModel):
+    model_config = {"extra": "forbid"}
     id: str
     type: str # 'subnet', 'internet', 'instance'
     security_groups: List[str] = []
 
 class Route(BaseModel):
+    model_config = {"extra": "forbid"}
     source: str
     destination: str
     target: str # e.g. 'igw', 'nat'
 
 class ComputedPath(BaseModel):
+    model_config = {"extra": "forbid"}
     reachable: bool
     path: List[str]
     reason: str
@@ -146,3 +159,43 @@ class NetworkGuard:
              return ComputedPath(reachable=False, path=path, reason=f"Routing exists but Security Group blocks port {port}")
 
         return ComputedPath(reachable=True, path=path, reason="Route exists and Security Groups allow traffic")
+
+    @staticmethod
+    def to_diagnostic(result: ComputedPath) -> InfraDiagnosticResult:
+        """Convert a ComputedPath to an InfraDiagnosticResult."""
+        if result.reachable:
+            trace = build_trace(NETWORK_REACHABILITY, "ALLOWED")
+            return InfraDiagnosticResult.verified(
+                agent_message="Network reachability verified",
+                developer_fields={
+                    "constraint_id": "network_guard.verify_reachability",
+                    "reachable": result.reachable,
+                    "path": result.path,
+                    "reason": result.reason,
+                    "audit_trace": trace,
+                },
+                evidence={**trace, "path": result.path, "reason": result.reason},
+            )
+
+        # Determine the rule from the reason string
+        reason_lower = result.reason.lower()
+        if "invalid internal source" in reason_lower:
+            rule = NETWORK_INVALID_INTERNAL
+        elif "not found in subnets" in reason_lower:
+            rule = NETWORK_UNKNOWN_DEST
+        elif "no route exists" in reason_lower:
+            rule = NETWORK_NO_ROUTE
+        else:
+            rule = NETWORK_SG_INGRESS
+
+        trace = build_trace(rule, "BLOCKED")
+        return InfraDiagnosticResult.blocked(
+            agent_message="Network reachability blocked",
+            developer_fields={
+                "constraint_id": "network_guard.verify_reachability",
+                "reachable": result.reachable,
+                "path": result.path,
+                "reason": result.reason,
+                "audit_trace": trace,
+            },
+        )

--- a/qwed_infra/guards/network_guard.py
+++ b/qwed_infra/guards/network_guard.py
@@ -184,7 +184,11 @@ class NetworkGuard:
             "unknown_destination": NETWORK_UNKNOWN_DEST,
             "sg_ingress_blocked": NETWORK_SG_INGRESS,
         }
-        rule = rule_map.get(result.failure_code, NETWORK_SG_INGRESS)
+        if not result.failure_code or result.failure_code not in rule_map:
+            raise ValueError(
+                f"ComputedPath missing or invalid failure_code: {result.failure_code!r}"
+            )
+        rule = rule_map[result.failure_code]
         trace = build_trace(rule, "BLOCKED")
         return InfraDiagnosticResult.blocked(
             agent_message="Network reachability blocked",

--- a/qwed_infra/guards/network_guard.py
+++ b/qwed_infra/guards/network_guard.py
@@ -13,6 +13,8 @@ from qwed_infra.audit import (
 )
 from qwed_infra.diagnostics import InfraDiagnosticResult
 
+_NETWORK_CONSTRAINT_ID = "network_guard.verify_reachability"
+
 class NetworkNode(BaseModel):
     model_config = {"extra": "forbid"}
     id: str
@@ -30,6 +32,8 @@ class ComputedPath(BaseModel):
     reachable: bool
     path: List[str]
     reason: str
+    port: int = 0
+    failure_code: str = ""
 
 class NetworkGuard:
     """
@@ -91,21 +95,20 @@ class NetworkGuard:
             try:
                 path = nx.shortest_path(self.graph, source, destination)
             except (nx.NetworkXNoPath, nx.NodeNotFound):
-                return ComputedPath(reachable=False, path=[], reason="No Route exists between nodes")
+                return ComputedPath(reachable=False, path=[], reason="No Route exists between nodes", port=port, failure_code="no_route")
         else:
             # Internal source — verify source is a valid IP address
             try:
                 ipaddress.ip_address(source)
             except ValueError:
-                return ComputedPath(reachable=False, path=[], reason=f"Invalid internal source: '{source}'")
+                return ComputedPath(reachable=False, path=[], reason=f"Invalid internal source: '{source}'", port=port, failure_code="invalid_internal_source")
             # Verify destination subnet exists in infra
             dest_exists = any(s["id"] == destination for s in resources.get("subnets", []))
             if not dest_exists:
-                return ComputedPath(reachable=False, path=[], reason=f"Destination '{destination}' not found in subnets")
+                return ComputedPath(reachable=False, path=[], reason=f"Destination '{destination}' not found in subnets", port=port, failure_code="unknown_destination")
             path = [source, destination]
             
         # 3. Check Security Groups (Firewall Logic)
-        # simplified: check destination ingress
         target_sgs = []
         
         # Find dest subnet definition
@@ -129,8 +132,6 @@ class NetworkGuard:
                 if not port_match:
                     continue
 
-                # CIDR check for ALL sources (internet and internal)
-                # Previously internal traffic skipped CIDR — false negative (#14)
                 if rule_cidr is None:
                     continue
 
@@ -142,7 +143,6 @@ class NetworkGuard:
                         addr = ipaddress.ip_address(source)
                         cidr_match = addr in network
                 except (ValueError, TypeError):
-                    # If CIDR or IP is unparseable, fail-closed
                     cidr_match = False
 
                 if cidr_match:
@@ -151,14 +151,13 @@ class NetworkGuard:
             if ingress_allowed:
                 break
 
-        # If no security groups attached, deny by default (fail-secure)
         if not target_sgs:
             ingress_allowed = False
             
         if not ingress_allowed:
-             return ComputedPath(reachable=False, path=path, reason=f"Routing exists but Security Group blocks port {port}")
+             return ComputedPath(reachable=False, path=path, reason=f"Routing exists but Security Group blocks port {port}", port=port, failure_code="sg_ingress_blocked")
 
-        return ComputedPath(reachable=True, path=path, reason="Route exists and Security Groups allow traffic")
+        return ComputedPath(reachable=True, path=path, reason="Route exists and Security Groups allow traffic", port=port)
 
     @staticmethod
     def to_diagnostic(result: ComputedPath) -> InfraDiagnosticResult:
@@ -168,34 +167,33 @@ class NetworkGuard:
             return InfraDiagnosticResult.verified(
                 agent_message="Network reachability verified",
                 developer_fields={
-                    "constraint_id": "network_guard.verify_reachability",
+                    "constraint_id": _NETWORK_CONSTRAINT_ID,
                     "reachable": result.reachable,
                     "path": result.path,
+                    "port": result.port,
                     "reason": result.reason,
                     "audit_trace": trace,
                 },
-                evidence={**trace, "path": result.path, "reason": result.reason},
+                evidence={**trace, "path": result.path, "port": result.port, "reason": result.reason},
             )
 
-        # Determine the rule from the reason string
-        reason_lower = result.reason.lower()
-        if "invalid internal source" in reason_lower:
-            rule = NETWORK_INVALID_INTERNAL
-        elif "not found in subnets" in reason_lower:
-            rule = NETWORK_UNKNOWN_DEST
-        elif "no route exists" in reason_lower:
-            rule = NETWORK_NO_ROUTE
-        else:
-            rule = NETWORK_SG_INGRESS
-
+        rule_map = {
+            "no_route": NETWORK_NO_ROUTE,
+            "invalid_internal_source": NETWORK_INVALID_INTERNAL,
+            "unknown_destination": NETWORK_UNKNOWN_DEST,
+            "sg_ingress_blocked": NETWORK_SG_INGRESS,
+        }
+        rule = rule_map.get(result.failure_code, NETWORK_SG_INGRESS)
         trace = build_trace(rule, "BLOCKED")
         return InfraDiagnosticResult.blocked(
             agent_message="Network reachability blocked",
             developer_fields={
-                "constraint_id": "network_guard.verify_reachability",
+                "constraint_id": _NETWORK_CONSTRAINT_ID,
                 "reachable": result.reachable,
                 "path": result.path,
+                "port": result.port,
                 "reason": result.reason,
+                "failure_code": result.failure_code,
                 "audit_trace": trace,
             },
         )

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,102 @@
+import pytest
+from qwed_infra.audit import (
+    COST_BUDGET_EXCEEDED,
+    COST_UNKNOWN_RESOURCE,
+    COST_WITHIN_BUDGET,
+    IAM_DATE_CONDITION,
+    IAM_DENY_PRECEDENCE,
+    IAM_IP_CONDITION,
+    IAM_STRING_CONDITION,
+    IAM_UNKNOWN_OPERATOR,
+    IAM_WILDCARD_MATCH,
+    NETWORK_INVALID_INTERNAL,
+    NETWORK_NO_ROUTE,
+    NETWORK_REACHABILITY,
+    NETWORK_SG_INGRESS,
+    NETWORK_UNKNOWN_DEST,
+    RuleRef,
+    build_trace,
+    trace_proof_ref,
+)
+
+
+class TestRuleRef:
+    def test_frozen(self):
+        r = RuleRef("TEST", "Test Statute")
+        with pytest.raises(AttributeError):
+            r.rule_id = "CHANGED"
+
+    def test_default_jurisdiction(self):
+        r = RuleRef("TEST", "Test Statute")
+        assert r.jurisdiction == "GENERIC"
+
+    def test_custom_jurisdiction(self):
+        r = RuleRef("TEST", "Test Statute", jurisdiction="US")
+        assert r.jurisdiction == "US"
+
+
+class TestRuleRefConstants:
+    def test_iam_constants_have_ids(self):
+        for ref in [
+            IAM_DENY_PRECEDENCE,
+            IAM_WILDCARD_MATCH,
+            IAM_IP_CONDITION,
+            IAM_DATE_CONDITION,
+            IAM_STRING_CONDITION,
+            IAM_UNKNOWN_OPERATOR,
+        ]:
+            assert ref.rule_id.startswith("IAM_")
+
+    def test_network_constants_have_ids(self):
+        for ref in [
+            NETWORK_SG_INGRESS,
+            NETWORK_REACHABILITY,
+            NETWORK_NO_ROUTE,
+            NETWORK_INVALID_INTERNAL,
+            NETWORK_UNKNOWN_DEST,
+        ]:
+            assert ref.rule_id.startswith("NETWORK_")
+
+    def test_cost_constants_have_ids(self):
+        for ref in [
+            COST_BUDGET_EXCEEDED,
+            COST_UNKNOWN_RESOURCE,
+            COST_WITHIN_BUDGET,
+        ]:
+            assert ref.rule_id.startswith("COST_")
+
+
+class TestBuildTrace:
+    def test_basic_trace(self):
+        trace = build_trace(IAM_DENY_PRECEDENCE, "DENIED")
+        assert trace["rule_id"] == "IAM_DENY_PRECEDENCE"
+        assert trace["outcome"] == "DENIED"
+        assert trace["inputs"] == {}
+
+    def test_trace_with_inputs(self):
+        trace = build_trace(IAM_DENY_PRECEDENCE, "DENIED", {"action": "s3:GetObject"})
+        assert trace["inputs"] == {"action": "s3:GetObject"}
+
+    def test_inputs_copy(self):
+        original = {"key": "value"}
+        trace = build_trace(IAM_DENY_PRECEDENCE, "DENIED", original)
+        original["key"] = "changed"
+        assert trace["inputs"]["key"] == "value"
+
+
+class TestTraceProofRef:
+    def test_deterministic_hash(self):
+        trace = build_trace(IAM_DENY_PRECEDENCE, "DENIED")
+        h1 = trace_proof_ref(trace)
+        h2 = trace_proof_ref(trace)
+        assert h1 == h2
+        assert h1.startswith("sha256:")
+
+    def test_different_trace_different_hash(self):
+        t1 = build_trace(IAM_DENY_PRECEDENCE, "DENIED")
+        t2 = build_trace(IAM_WILDCARD_MATCH, "ALLOWED")
+        assert trace_proof_ref(t1) != trace_proof_ref(t2)
+
+    def test_non_json_serializable_raises(self):
+        with pytest.raises(ValueError, match="JSON-serializable"):
+            trace_proof_ref({"bad": object()})

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -18,7 +18,7 @@ class TestInfraDiagnosticResultConstruction:
     def test_minimal_verified(self):
         result = InfraDiagnosticResult.verified(
             agent_message="All checks passed",
-            developer_fields={"constraint_id": "test"},
+            developer_fields={"constraint_id": "test", "audit_trace": {"rule_id": "test_rule"}},
             evidence={"rule": "test_rule"},
         )
         assert result.status is InfraDiagnosticStatus.VERIFIED
@@ -125,7 +125,7 @@ class TestInfraDiagnosticResultSerialization:
     def test_to_dict_verified(self):
         r = InfraDiagnosticResult.verified(
             agent_message="OK",
-            developer_fields={"constraint_id": "t1"},
+            developer_fields={"constraint_id": "t1", "audit_trace": {"rule_id": "test"}},
             evidence={"key": "val"},
         )
         d = r.to_dict()
@@ -147,7 +147,7 @@ class TestInfraDiagnosticResultSerialization:
     def test_from_dict_roundtrip(self):
         original = InfraDiagnosticResult.verified(
             agent_message="Roundtrip test",
-            developer_fields={"constraint_id": "t1"},
+            developer_fields={"constraint_id": "t1", "audit_trace": {"rule_id": "test"}},
             evidence={"key": "val"},
         )
         d = original.to_dict()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,214 @@
+import pytest
+from qwed_infra.diagnostics import (
+    InfraAdvisoryCheck,
+    InfraDiagnosticResult,
+    InfraDiagnosticStatus,
+    compute_proof_ref,
+)
+
+
+class TestInfraDiagnosticStatus:
+    def test_three_states(self):
+        assert InfraDiagnosticStatus.VERIFIED.value == "VERIFIED"
+        assert InfraDiagnosticStatus.UNVERIFIABLE.value == "UNVERIFIABLE"
+        assert InfraDiagnosticStatus.BLOCKED.value == "BLOCKED"
+
+
+class TestInfraDiagnosticResultConstruction:
+    def test_minimal_verified(self):
+        result = InfraDiagnosticResult.verified(
+            agent_message="All checks passed",
+            developer_fields={"constraint_id": "test"},
+            evidence={"rule": "test_rule"},
+        )
+        assert result.status is InfraDiagnosticStatus.VERIFIED
+        assert result.is_verified is True
+        assert result.is_authoritative is True
+        assert result.proof_ref is not None
+        assert result.proof_ref.startswith("sha256:")
+
+    def test_unverifiable(self):
+        result = InfraDiagnosticResult.unverifiable(
+            agent_message="Could not verify",
+            developer_fields={"constraint_id": "test"},
+        )
+        assert result.status is InfraDiagnosticStatus.UNVERIFIABLE
+        assert result.is_verified is False
+        assert result.is_authoritative is False
+        assert result.is_fail_closed is True
+        assert result.proof_ref is None
+
+    def test_blocked(self):
+        result = InfraDiagnosticResult.blocked(
+            agent_message="Verification blocked",
+            developer_fields={"constraint_id": "test"},
+        )
+        assert result.status is InfraDiagnosticStatus.BLOCKED
+        assert result.is_verified is False
+        assert result.is_authoritative is False
+        assert result.is_fail_closed is True
+        assert result.proof_ref is None
+
+    def test_verified_without_evidence_raises(self):
+        with pytest.raises(ValueError, match="proof_ref"):
+            InfraDiagnosticResult(
+                status=InfraDiagnosticStatus.VERIFIED,
+                agent_message="test",
+                developer_fields={},
+                proof_ref=None,
+            )
+
+    def test_non_verified_with_proof_ref_raises(self):
+        with pytest.raises(ValueError, match="proof_ref"):
+            InfraDiagnosticResult(
+                status=InfraDiagnosticStatus.UNVERIFIABLE,
+                agent_message="test",
+                developer_fields={},
+                proof_ref="sha256:abc",
+            )
+
+    def test_empty_agent_message_raises(self):
+        with pytest.raises(ValueError, match="agent_message"):
+            InfraDiagnosticResult(
+                status=InfraDiagnosticStatus.UNVERIFIABLE,
+                agent_message="",
+                developer_fields={},
+            )
+
+    def test_non_dict_developer_fields_raises(self):
+        with pytest.raises(ValueError, match="developer_fields"):
+            InfraDiagnosticResult(
+                status=InfraDiagnosticStatus.UNVERIFIABLE,
+                agent_message="test",
+                developer_fields="not-a-dict",
+            )
+
+    def test_frozen(self):
+        result = InfraDiagnosticResult.unverifiable(
+            agent_message="test", developer_fields={}
+        )
+        with pytest.raises(AttributeError):
+            result.agent_message = "changed"
+
+
+class TestInfraDiagnosticResultProperties:
+    def test_constraint_id(self):
+        r = InfraDiagnosticResult.unverifiable(
+            agent_message="test",
+            developer_fields={"constraint_id": "my.guard.check"},
+        )
+        assert r.constraint_id == "my.guard.check"
+
+    def test_audit_trace(self):
+        r = InfraDiagnosticResult.unverifiable(
+            agent_message="test",
+            developer_fields={"audit_trace": {"rule_id": "R1"}},
+        )
+        assert r.audit_trace == {"rule_id": "R1"}
+
+    def test_advisory_checks(self):
+        r = InfraDiagnosticResult.unverifiable(
+            agent_message="test",
+            developer_fields={
+                "advisory_checks": [
+                    {"name": "check1", "constraint_id": "c1"},
+                ]
+            },
+        )
+        checks = r.advisory_checks
+        assert len(checks) == 1
+        assert checks[0].name == "check1"
+        assert checks[0].advisory_only is True
+
+
+class TestInfraDiagnosticResultSerialization:
+    def test_to_dict_verified(self):
+        r = InfraDiagnosticResult.verified(
+            agent_message="OK",
+            developer_fields={"constraint_id": "t1"},
+            evidence={"key": "val"},
+        )
+        d = r.to_dict()
+        assert d["status"] == "VERIFIED"
+        assert d["agent_message"] == "OK"
+        assert d["is_authoritative"] is True
+        assert d["proof_ref"].startswith("sha256:")
+
+    def test_to_dict_unverifiable(self):
+        r = InfraDiagnosticResult.unverifiable(
+            agent_message="Not sure",
+            developer_fields={"constraint_id": "t1"},
+        )
+        d = r.to_dict()
+        assert d["status"] == "UNVERIFIABLE"
+        assert d["proof_ref"] is None
+        assert d["is_authoritative"] is False
+
+    def test_from_dict_roundtrip(self):
+        original = InfraDiagnosticResult.verified(
+            agent_message="Roundtrip test",
+            developer_fields={"constraint_id": "t1"},
+            evidence={"key": "val"},
+        )
+        d = original.to_dict()
+        restored = InfraDiagnosticResult.from_dict(d)
+        assert restored.status == original.status
+        assert restored.agent_message == original.agent_message
+        assert restored.proof_ref == original.proof_ref
+        assert restored.developer_fields["constraint_id"] == "t1"
+
+    def test_from_dict_missing_agent_message_raises(self):
+        with pytest.raises(ValueError, match="agent_message"):
+            InfraDiagnosticResult.from_dict({"status": "BLOCKED"})
+
+    def test_from_dict_invalid_status_raises(self):
+        with pytest.raises(ValueError, match="invalid status"):
+            InfraDiagnosticResult.from_dict(
+                {"status": "NONSENSE", "agent_message": "test"}
+            )
+
+
+class TestInfraAdvisoryCheck:
+    def test_frozen(self):
+        c = InfraAdvisoryCheck(name="test")
+        with pytest.raises(AttributeError):
+            c.name = "changed"
+
+    def test_advisory_only_must_be_true(self):
+        with pytest.raises(ValueError, match="advisory_only"):
+            InfraAdvisoryCheck(name="bad", advisory_only=False)
+
+    def test_to_dict_roundtrip(self):
+        c = InfraAdvisoryCheck(
+            name="check1",
+            constraint_id="c1",
+            details={"key": "val"},
+        )
+        d = c.to_dict()
+        restored = InfraAdvisoryCheck.from_dict(d)
+        assert restored.name == "check1"
+        assert restored.constraint_id == "c1"
+        assert restored.details == {"key": "val"}
+
+    def test_from_dict_int_advisory_only(self):
+        c = InfraAdvisoryCheck.from_dict({"name": "test", "advisory_only": 1})
+        assert c.advisory_only is True
+
+    def test_from_dict_invalid_advisory_only_raises(self):
+        with pytest.raises(ValueError, match="advisory_only"):
+            InfraAdvisoryCheck.from_dict({"name": "test", "advisory_only": "maybe"})
+
+
+class TestComputeProofRef:
+    def test_deterministic(self):
+        e1 = compute_proof_ref({"a": 1, "b": 2})
+        e2 = compute_proof_ref({"b": 2, "a": 1})
+        assert e1 == e2
+
+    def test_prefix(self):
+        h = compute_proof_ref({"key": "val"})
+        assert h.startswith("sha256:")
+
+    def test_non_json_serializable_raises(self):
+        with pytest.raises(ValueError, match="JSON-serializable"):
+            compute_proof_ref({"bad": object()})

--- a/tests/test_guard_diagnostics.py
+++ b/tests/test_guard_diagnostics.py
@@ -30,8 +30,9 @@ class TestIamGuardToDiagnostic:
             error="Something went wrong",
         )
         diagnostic = IamGuard.to_diagnostic(result)
-        assert diagnostic.status is InfraDiagnosticStatus.BLOCKED
+        assert diagnostic.status is InfraDiagnosticStatus.UNVERIFIABLE
         assert diagnostic.is_verified is False
+        assert diagnostic.is_fail_closed is True
         assert diagnostic.proof_ref is None
         assert "error" in diagnostic.developer_fields
 
@@ -61,6 +62,7 @@ class TestNetworkGuardToDiagnostic:
             reachable=False,
             path=["internet", "subnet-a"],
             reason="Routing exists but Security Group blocks port 80",
+            failure_code="sg_ingress_blocked",
         )
         diagnostic = NetworkGuard.to_diagnostic(result)
         assert diagnostic.status is InfraDiagnosticStatus.BLOCKED

--- a/tests/test_guard_diagnostics.py
+++ b/tests/test_guard_diagnostics.py
@@ -1,0 +1,173 @@
+import pytest
+from qwed_infra.diagnostics import InfraDiagnosticStatus
+from qwed_infra.guards.iam_guard import IamGuard, VerificationResult
+from qwed_infra.guards.network_guard import ComputedPath, NetworkGuard
+from qwed_infra.guards.cost_guard import CostEstimate, CostGuard
+
+
+class TestIamGuardToDiagnostic:
+    def test_verified_allowed(self):
+        result = VerificationResult(verified=True, allowed=True, proof="Z3 sat")
+        diagnostic = IamGuard.to_diagnostic(result)
+        assert diagnostic.status is InfraDiagnosticStatus.VERIFIED
+        assert diagnostic.is_verified is True
+        assert diagnostic.proof_ref is not None
+        assert diagnostic.developer_fields["allowed"] is True
+
+    def test_verified_denied(self):
+        result = VerificationResult(verified=True, allowed=False, proof="Z3 unsat")
+        diagnostic = IamGuard.to_diagnostic(result)
+        assert diagnostic.status is InfraDiagnosticStatus.VERIFIED
+        assert diagnostic.is_verified is True
+        assert diagnostic.proof_ref is not None
+        assert diagnostic.developer_fields["allowed"] is False
+
+    def test_not_verified(self):
+        result = VerificationResult(
+            verified=False,
+            allowed=False,
+            error="Something went wrong",
+        )
+        diagnostic = IamGuard.to_diagnostic(result)
+        assert diagnostic.status is InfraDiagnosticStatus.BLOCKED
+        assert diagnostic.is_verified is False
+        assert diagnostic.proof_ref is None
+        assert "error" in diagnostic.developer_fields
+
+    def test_with_audit_trace(self):
+        result = VerificationResult(verified=True, allowed=True, proof="Z3 sat")
+        trace = {"rule_id": "IAM_DENY_PRECEDENCE", "outcome": "ALLOWED"}
+        diagnostic = IamGuard.to_diagnostic(result, audit_trace=trace)
+        assert diagnostic.developer_fields["audit_trace"] == trace
+        assert diagnostic.audit_trace == trace
+
+
+class TestNetworkGuardToDiagnostic:
+    def test_reachable(self):
+        result = ComputedPath(
+            reachable=True,
+            path=["internet", "subnet-a"],
+            reason="Route exists and Security Groups allow traffic",
+        )
+        diagnostic = NetworkGuard.to_diagnostic(result)
+        assert diagnostic.status is InfraDiagnosticStatus.VERIFIED
+        assert diagnostic.is_verified is True
+        assert diagnostic.proof_ref is not None
+        assert diagnostic.developer_fields["reachable"] is True
+
+    def test_blocked_by_sg(self):
+        result = ComputedPath(
+            reachable=False,
+            path=["internet", "subnet-a"],
+            reason="Routing exists but Security Group blocks port 80",
+        )
+        diagnostic = NetworkGuard.to_diagnostic(result)
+        assert diagnostic.status is InfraDiagnosticStatus.BLOCKED
+        assert diagnostic.is_verified is False
+        assert diagnostic.proof_ref is None
+
+    def test_no_route(self):
+        result = ComputedPath(
+            reachable=False,
+            path=[],
+            reason="No Route exists between nodes",
+        )
+        diagnostic = NetworkGuard.to_diagnostic(result)
+        assert diagnostic.status is InfraDiagnosticStatus.BLOCKED
+        assert diagnostic.developer_fields["audit_trace"]["rule_id"] == "NETWORK_NO_ROUTE"
+
+    def test_invalid_internal_source(self):
+        result = ComputedPath(
+            reachable=False,
+            path=[],
+            reason="Invalid internal source: 'not-an-ip'",
+        )
+        diagnostic = NetworkGuard.to_diagnostic(result)
+        assert diagnostic.status is InfraDiagnosticStatus.BLOCKED
+        assert diagnostic.developer_fields["audit_trace"]["rule_id"] == "NETWORK_INVALID_INTERNAL"
+
+    def test_unknown_destination(self):
+        result = ComputedPath(
+            reachable=False,
+            path=[],
+            reason="Destination 'subnet-ghost' not found in subnets",
+        )
+        diagnostic = NetworkGuard.to_diagnostic(result)
+        assert diagnostic.status is InfraDiagnosticStatus.BLOCKED
+        assert diagnostic.developer_fields["audit_trace"]["rule_id"] == "NETWORK_UNKNOWN_DEST"
+
+
+class TestCostGuardToDiagnostic:
+    def test_within_budget(self):
+        result = CostEstimate(
+            total_monthly_cost=50.0,
+            breakdown={"web": 50.0},
+            within_budget=True,
+            budget=100.0,
+            reason="Estimated cost $50.00 is within budget $100.00",
+        )
+        diagnostic = CostGuard.to_diagnostic(result)
+        assert diagnostic.status is InfraDiagnosticStatus.VERIFIED
+        assert diagnostic.is_verified is True
+        assert diagnostic.proof_ref is not None
+        assert diagnostic.developer_fields["within_budget"] is True
+
+    def test_exceeds_budget(self):
+        result = CostEstimate(
+            total_monthly_cost=200.0,
+            breakdown={"web": 200.0},
+            within_budget=False,
+            budget=100.0,
+            reason="Estimated cost $200.00 EXCEEDS budget $100.00",
+        )
+        diagnostic = CostGuard.to_diagnostic(result)
+        assert diagnostic.status is InfraDiagnosticStatus.VERIFIED
+        assert diagnostic.is_verified is True
+        assert diagnostic.developer_fields["audit_trace"]["rule_id"] == "COST_BUDGET_EXCEEDED"
+
+    def test_unknown_instance_type(self):
+        result = CostEstimate(
+            total_monthly_cost=50.0,
+            breakdown={},
+            within_budget=False,
+            budget=100.0,
+            reason="Cost estimate incomplete \u2014 unknown instance types: ['g6.xlarge']. Known cost $50.00 vs budget $100.00.",
+        )
+        diagnostic = CostGuard.to_diagnostic(result)
+        assert diagnostic.status is InfraDiagnosticStatus.BLOCKED
+        assert diagnostic.is_verified is False
+        assert diagnostic.proof_ref is None
+        assert diagnostic.developer_fields["audit_trace"]["rule_id"] == "COST_UNKNOWN_RESOURCE"
+
+
+class TestPydanticExtraForbid:
+    def test_iam_policy_rejects_extra(self):
+        from qwed_infra.guards.iam_guard import IamPolicy
+
+        with pytest.raises(Exception):
+            IamPolicy(Version="2012-10-17", Statement=[], extra_field="bad")
+
+    def test_verification_result_rejects_extra(self):
+        from qwed_infra.guards.iam_guard import VerificationResult
+
+        with pytest.raises(Exception):
+            VerificationResult(verified=True, allowed=True, extra="bad")
+
+    def test_computed_path_rejects_extra(self):
+        from qwed_infra.guards.network_guard import ComputedPath
+
+        with pytest.raises(Exception):
+            ComputedPath(reachable=True, path=[], reason="ok", extra="bad")
+
+    def test_cost_estimate_rejects_extra(self):
+        from qwed_infra.guards.cost_guard import CostEstimate
+
+        with pytest.raises(Exception):
+            CostEstimate(
+                total_monthly_cost=0,
+                breakdown={},
+                within_budget=True,
+                budget=100,
+                reason="ok",
+                extra="bad",
+            )

--- a/tests/test_guard_diagnostics.py
+++ b/tests/test_guard_diagnostics.py
@@ -148,6 +148,28 @@ class TestCostGuardToDiagnostic:
         assert diagnostic.developer_fields["audit_trace"]["rule_id"] == "COST_UNKNOWN_RESOURCE"
         assert diagnostic.developer_fields["has_unknown_types"] is True
 
+    def test_verify_budget_marks_unknown_types_blocked(self):
+        estimate = CostGuard().verify_budget(
+            {"instances": [{"id": "gpu-1", "instance_type": "g6.xlarge", "count": 1}]},
+            budget_monthly=100.0,
+        )
+        assert estimate.has_unknown_types is True
+        diagnostic = CostGuard.to_diagnostic(estimate)
+        assert diagnostic.status is InfraDiagnosticStatus.BLOCKED
+        assert diagnostic.developer_fields["audit_trace"]["rule_id"] == "COST_UNKNOWN_RESOURCE"
+
+    def test_mismatched_within_budget_blocked(self):
+        result = CostEstimate(
+            total_monthly_cost=200.0,
+            breakdown={"web": 200.0},
+            within_budget=True,
+            budget=100.0,
+            reason="Cost exceeds budget but claims within_budget",
+        )
+        diagnostic = CostGuard.to_diagnostic(result)
+        assert diagnostic.status is InfraDiagnosticStatus.BLOCKED
+        assert diagnostic.developer_fields["audit_trace"]["outcome"] == "INCONSISTENT"
+
 
 class TestPydanticExtraForbid:
     def test_iam_policy_rejects_extra(self):

--- a/tests/test_guard_diagnostics.py
+++ b/tests/test_guard_diagnostics.py
@@ -1,3 +1,4 @@
+import pydantic
 import pytest
 from qwed_infra.diagnostics import InfraDiagnosticStatus
 from qwed_infra.guards.iam_guard import IamGuard, VerificationResult
@@ -71,16 +72,19 @@ class TestNetworkGuardToDiagnostic:
             reachable=False,
             path=[],
             reason="No Route exists between nodes",
+            failure_code="no_route",
         )
         diagnostic = NetworkGuard.to_diagnostic(result)
         assert diagnostic.status is InfraDiagnosticStatus.BLOCKED
         assert diagnostic.developer_fields["audit_trace"]["rule_id"] == "NETWORK_NO_ROUTE"
+        assert diagnostic.developer_fields["failure_code"] == "no_route"
 
     def test_invalid_internal_source(self):
         result = ComputedPath(
             reachable=False,
             path=[],
             reason="Invalid internal source: 'not-an-ip'",
+            failure_code="invalid_internal_source",
         )
         diagnostic = NetworkGuard.to_diagnostic(result)
         assert diagnostic.status is InfraDiagnosticStatus.BLOCKED
@@ -91,6 +95,7 @@ class TestNetworkGuardToDiagnostic:
             reachable=False,
             path=[],
             reason="Destination 'subnet-ghost' not found in subnets",
+            failure_code="unknown_destination",
         )
         diagnostic = NetworkGuard.to_diagnostic(result)
         assert diagnostic.status is InfraDiagnosticStatus.BLOCKED
@@ -132,37 +137,39 @@ class TestCostGuardToDiagnostic:
             within_budget=False,
             budget=100.0,
             reason="Cost estimate incomplete \u2014 unknown instance types: ['g6.xlarge']. Known cost $50.00 vs budget $100.00.",
+            has_unknown_types=True,
         )
         diagnostic = CostGuard.to_diagnostic(result)
         assert diagnostic.status is InfraDiagnosticStatus.BLOCKED
         assert diagnostic.is_verified is False
         assert diagnostic.proof_ref is None
         assert diagnostic.developer_fields["audit_trace"]["rule_id"] == "COST_UNKNOWN_RESOURCE"
+        assert diagnostic.developer_fields["has_unknown_types"] is True
 
 
 class TestPydanticExtraForbid:
     def test_iam_policy_rejects_extra(self):
         from qwed_infra.guards.iam_guard import IamPolicy
 
-        with pytest.raises(Exception):
+        with pytest.raises(pydantic.ValidationError):
             IamPolicy(Version="2012-10-17", Statement=[], extra_field="bad")
 
     def test_verification_result_rejects_extra(self):
         from qwed_infra.guards.iam_guard import VerificationResult
 
-        with pytest.raises(Exception):
+        with pytest.raises(pydantic.ValidationError):
             VerificationResult(verified=True, allowed=True, extra="bad")
 
     def test_computed_path_rejects_extra(self):
         from qwed_infra.guards.network_guard import ComputedPath
 
-        with pytest.raises(Exception):
+        with pytest.raises(pydantic.ValidationError):
             ComputedPath(reachable=True, path=[], reason="ok", extra="bad")
 
     def test_cost_estimate_rejects_extra(self):
         from qwed_infra.guards.cost_guard import CostEstimate
 
-        with pytest.raises(Exception):
+        with pytest.raises(pydantic.ValidationError):
             CostEstimate(
                 total_monthly_cost=0,
                 breakdown={},

--- a/tests/test_guard_diagnostics.py
+++ b/tests/test_guard_diagnostics.py
@@ -126,8 +126,10 @@ class TestCostGuardToDiagnostic:
             reason="Estimated cost $200.00 EXCEEDS budget $100.00",
         )
         diagnostic = CostGuard.to_diagnostic(result)
-        assert diagnostic.status is InfraDiagnosticStatus.VERIFIED
-        assert diagnostic.is_verified is True
+        assert diagnostic.status is InfraDiagnosticStatus.BLOCKED
+        assert diagnostic.is_verified is False
+        assert diagnostic.is_fail_closed is True
+        assert diagnostic.proof_ref is None
         assert diagnostic.developer_fields["audit_trace"]["rule_id"] == "COST_BUDGET_EXCEEDED"
 
     def test_unknown_instance_type(self):


### PR DESCRIPTION
**Description:**

Ports the structured diagnostic architecture from qwed-tax v0.2.0 to qwed-infra. No cross-package dependency — independent implementation following the same 3-layer pattern.

**New files:**

- **`qwed_infra/audit.py`** — `RuleRef` frozen dataclass, `build_trace()`, `trace_proof_ref()`, 13 infra-specific rule constants (IAM_DENY_PRECEDENCE, IAM_WILDCARD_MATCH, IAM_IP_CONDITION, IAM_DATE_CONDITION, IAM_STRING_CONDITION, IAM_UNKNOWN_OPERATOR, NETWORK_SG_INGRESS, NETWORK_REACHABILITY, NETWORK_NO_ROUTE, NETWORK_INVALID_INTERNAL, NETWORK_UNKNOWN_DEST, COST_BUDGET_EXCEEDED, COST_UNKNOWN_RESOURCE, COST_WITHIN_BUDGET)

- **`qwed_infra/diagnostics.py`** — 3-layer `InfraDiagnosticResult` model:
  - `InfraDiagnosticStatus` (VERIFIED / UNVERIFIABLE / BLOCKED)
  - `InfraAdvisoryCheck` (advisory-only non-proof metadata)
  - `compute_proof_ref()` (SHA-256 deterministic hash)
  - `InfraDiagnosticResult` frozen dataclass with factory methods (`verified()`, `unverifiable()`, `blocked()`), properties (`is_verified`, `is_authoritative`, `is_fail_closed`, `constraint_id`, `audit_trace`, `advisory_checks`), and serialization (`to_dict`/`from_dict`)
  - Invariants: VERIFIED requires `proof_ref != None`, non-VERIFIED requires `proof_ref == None`, `agent_message` must be non-empty, `developer_fields` must be dict

**Guard changes (additive — legacy returns preserved):**

| Guard | `to_diagnostic()` | `extra="forbid"` |
|-------|-------------------|------------------|
| IamGuard | `VerificationResult` → `InfraDiagnosticResult` with Z3 evidence | `IamPolicy`, `VerificationResult` |
| NetworkGuard | `ComputedPath` → `InfraDiagnosticResult` with graph path + SG evidence | `NetworkNode`, `Route`, `ComputedPath` |
| CostGuard | `CostEstimate` → `InfraDiagnosticResult` with pricing evidence | `CostEstimate` |

**State after this PR:**

| Guard | Return type | audit_trace | proof_ref | to_diagnostic() |
|-------|-------------|-------------|-----------|-----------------|
| IamGuard | VerificationResult | ✅ | ✅ | ✅ |
| NetworkGuard | ComputedPath | ✅ | ✅ | ✅ |
| CostGuard | CostEstimate | ✅ | ✅ | ✅ |

**Tests:** 53 new tests across 3 files (test_audit.py, test_diagnostics.py, test_guard_diagnostics.py). Total: 190, all passing.

Closes #19.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added standardized machine-readable audit tracing with deterministic `sha256:` proof references.
  * Introduced a 3-state diagnostics model (verified, unverifiable, blocked) and structured diagnostics for IAM, network reachability, and cost budget checks.
  * Added guard-to-diagnostics converters with richer evidence and network `failure_code` details.
* **Bug Fixes**
  * Hardened guard models to reject unknown/extra fields; improved network and cost diagnostic consistency handling.
* **Tests**
  * Added unit tests covering audit helpers, diagnostics serialization/validation, and guard diagnostic conversions (including failure scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->