### PR TITLE
fix #17: honest Z3 scope labeling + condition_evaluations audit trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ AI agents like **Devin**, **GitHub Copilot Workspace**, and **Cursor** are writi
 ## 💡 What QWED-Infra Is (and Isn't)
 
 ### ✅ QWED-Infra IS:
-*   **A Mathematical Proof Engine:** Uses **Z3 Theorem Prover** to *prove* your IAM policies are secure.
+*   **A Deterministic Verification Engine:** Uses **Z3 Theorem Prover** to *prove* IAM action/resource matching, with IP and date conditions evaluated deterministically in Python.
 *   **A Graph Analyzer:** Uses **NetworkX** to map and verify network reachability (Reachability Analysis).
 *   **Deterministic:** Inputs are code, output is `True/False` with 100% certainty.
 *   **A "Guard" Layer:** Plugs into CI/CD to block AI-generated PRs that violate rules.
@@ -49,7 +49,7 @@ AI agents like **Devin**, **GitHub Copilot Workspace**, and **Cursor** are writi
 | **IAM Logic** | Can catch `s3:*` text match | Proves `Allow` overrides `Deny` logically |
 | **Network** | Checks generic "port 22 open" | Traces `Internet -> IGW -> Route -> SG -> VM` |
 | **Cost** | N/A (usually distinct tools) | **Deterministic Pre-Deployment Estimation** |
-| **Accuracy** | High False Positives | **Mathematically Proven Correctness** |
+| **Accuracy** | High False Positives | **Deterministic Correctness** |
 
 ---
 
@@ -57,9 +57,9 @@ AI agents like **Devin**, **GitHub Copilot Workspace**, and **Cursor** are writi
 
 ### 1. IamGuard (The Security Math)
 Converts AWS IAM Policies into logical formulas.
-*   **Wildcards:** Handles `s3:Get*` vs `s3:GetObject`.
-*   **Logic:** Proves `Deny` statements always win.
-*   **Context:** Verifies against specific conditions (e.g., `aws:SourceIp`).
+*   **Wildcards:** Handles `s3:Get*` vs `s3:GetObject` — proved symbolically in Z3.
+*   **Logic:** Proves `Deny` statements always win — proved symbolically in Z3.
+*   **Context:** Verifies against specific conditions (e.g., `aws:SourceIp`, `aws:CurrentTime`) — evaluated deterministically in Python, with full trace in diagnostic output.
 
 ### 2. NetworkGuard (The Topology Graph)
 Builds a directed graph of your VPC.

--- a/qwed_infra/guards/iam_guard.py
+++ b/qwed_infra/guards/iam_guard.py
@@ -340,7 +340,7 @@ class IamGuard:
         if audit_trace is not None:
             trace = dict(audit_trace)
             if trace_inputs:
-                trace["inputs"] = trace_inputs
+                trace["inputs"] = {**trace.get("inputs", {}), **trace_inputs}
         else:
             trace = build_trace(rule, outcome, inputs=trace_inputs)
 

--- a/qwed_infra/guards/iam_guard.py
+++ b/qwed_infra/guards/iam_guard.py
@@ -257,17 +257,19 @@ class IamGuard:
             query = And(s_action == StringVal(action), s_resource == StringVal(resource))
 
             # Collect condition metadata for audit trace
+            _Z3_OPS = {"StringEquals", "StringLike"}
             condition_evaluations = []
             for stmt in policy.get("Statement", []):
                 conditions = stmt.get("Condition", {})
                 for operator, restrictions in conditions.items():
+                    evaluated_in = "z3" if operator in _Z3_OPS else "python"
                     for key, required_val in restrictions.items():
                         condition_evaluations.append({
                             "operator": operator,
                             "key": key,
-                            "context_value": context.get(key),
-                            "required_value": required_val,
-                            "evaluated_in": "python",
+                            "context_value": str(context.get(key)),
+                            "required_value": str(required_val),
+                            "evaluated_in": evaluated_in,
                         })
 
             policy_logic = self._build_policy_logic(policy, s_action, s_resource, context)
@@ -335,7 +337,12 @@ class IamGuard:
             outcome = "DENIED"
 
         trace_inputs = {"condition_evaluations": result.condition_evaluations} if result.condition_evaluations else None
-        trace = audit_trace if audit_trace is not None else build_trace(rule, outcome, inputs=trace_inputs)
+        if audit_trace is not None:
+            trace = dict(audit_trace)
+            if trace_inputs:
+                trace["inputs"] = trace_inputs
+        else:
+            trace = build_trace(rule, outcome, inputs=trace_inputs)
 
         evidence = {
             "verified": result.verified,

--- a/qwed_infra/guards/iam_guard.py
+++ b/qwed_infra/guards/iam_guard.py
@@ -31,6 +31,7 @@ class VerificationResult(BaseModel):
     allowed: bool
     proof: Optional[str] = None
     error: Optional[str] = None
+    condition_evaluations: List[Dict[str, Any]] = []
 
 
 class IamGuard:
@@ -255,6 +256,20 @@ class IamGuard:
             s_resource = String("resource")
             query = And(s_action == StringVal(action), s_resource == StringVal(resource))
 
+            # Collect condition metadata for audit trace
+            condition_evaluations = []
+            for stmt in policy.get("Statement", []):
+                conditions = stmt.get("Condition", {})
+                for operator, restrictions in conditions.items():
+                    for key, required_val in restrictions.items():
+                        condition_evaluations.append({
+                            "operator": operator,
+                            "key": key,
+                            "context_value": context.get(key),
+                            "required_value": required_val,
+                            "evaluated_in": "python",
+                        })
+
             policy_logic = self._build_policy_logic(policy, s_action, s_resource, context)
 
             self.solver.reset()
@@ -266,11 +281,13 @@ class IamGuard:
                     verified=True,
                     allowed=True,
                     proof="Z3 found a satisfying model (Access Allowed)",
+                    condition_evaluations=condition_evaluations,
                 )
             return VerificationResult(
                 verified=True,
                 allowed=False,
                 proof="Z3 proved unsatisfiability (Access Denied)",
+                condition_evaluations=condition_evaluations,
             )
         except Exception as exc:  # noqa: BLE001
             return VerificationResult(
@@ -317,7 +334,8 @@ class IamGuard:
         else:
             outcome = "DENIED"
 
-        trace = audit_trace if audit_trace is not None else build_trace(rule, outcome)
+        trace_inputs = {"condition_evaluations": result.condition_evaluations} if result.condition_evaluations else None
+        trace = audit_trace if audit_trace is not None else build_trace(rule, outcome, inputs=trace_inputs)
 
         evidence = {
             "verified": result.verified,
@@ -325,6 +343,8 @@ class IamGuard:
             "proof": result.proof,
             "audit_trace": trace,
         }
+        if result.condition_evaluations:
+            evidence["condition_evaluations"] = result.condition_evaluations
 
         agent_msg = "IAM policy access: allowed" if result.allowed else "IAM policy access: denied"
         return InfraDiagnosticResult.verified(


### PR DESCRIPTION
Implements Option B from #17 — keeps Python evaluation for IP/date conditions
(deterministic and correct) but adds structured audit trace transparency.

### Changes

1. **`VerificationResult.condition_evaluations`** — new field capturing each
   condition operator, key, context value, required value, and `evaluated_in:
   "python"` flag.

2. **`verify_access`** — collects condition metadata before Z3 execution,
   attached to every `VerificationResult`.

3. **`to_diagnostic`** — includes `condition_evaluations` in the audit trace
   `inputs` and `evidence` dict, so the full evaluation context is bound to the
   `proof_ref`.

4. **README honest labeling:**
   - "Mathematical Proof Engine" → deterministic verification with Z3/Python scope
   - "Mathematically Proven Correctness" → "Deterministic Correctness"
   - IamGuard bullets now say "proved symbolically in Z3" for wildcards/logic
     and "evaluated deterministically in Python" for IP/date conditions

### What this does NOT change

- IP/date condition logic remains Python-based (deterministic — no behavioral
  change)
- `verified()`, `blocked()`, `unverifiable()` semantics unchanged
- All 192 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added richer access verification details, including per-condition evaluation metadata in IAM-related results and diagnostics.
  - Expanded audit traces to show how condition checks were evaluated, including context and required values.

- **Documentation**
  - Updated the README to describe the system as a deterministic verification engine and clarify how IAM matching and conditions are handled.

- **Bug Fixes**
  - Improved access decision reporting so both allowed and denied outcomes now include condition evaluation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->