### PR TITLE
fix #12: NetworkGuard unsupported topology — fail-closed, port ranges, honest README, remove dead code

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ print(result.reachable)  # -> True (Risk Alert!)
 
 # Convert to structured diagnostic for CI/CD enforcement
 diagnostic = NetworkGuard.to_diagnostic(result)
-print(diagnostic.status)  # -> VERIFIED / BLOCKED / UNVERIFIABLE
+print(diagnostic.status.value)  # -> VERIFIED / BLOCKED / UNVERIFIABLE
 ```
 
 ### Enforce Budget

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ AI agents like **Devin**, **GitHub Copilot Workspace**, and **Cursor** are writi
 | :--- | :--- | :--- |
 | **Approach** | Regex / Static Pattern Matching | **Symbolic Execution (Z3) & Graph Theory** |
 | **IAM Logic** | Can catch `s3:*` text match | Proves `Allow` overrides `Deny` logically |
-| **Network** | Checks generic "port 22 open" | Traces `Internet -> IGW -> Route -> SG -> VM` |
+| **Network** | Checks generic "port 22 open" | Traces `Internet -> IGW -> Route -> SG -> Subnet` (fail-closed on NAT/NACL/peering) |
 | **Cost** | N/A (usually distinct tools) | **Deterministic Pre-Deployment Estimation** |
 | **Accuracy** | High False Positives | **Deterministic Correctness** |
 
@@ -64,7 +64,8 @@ Converts AWS IAM Policies into logical formulas.
 ### 2. NetworkGuard (The Topology Graph)
 Builds a directed graph of your VPC.
 *   **Reachability:** "Can an attacker on the Internet reach my Database?"
-*   **Path Analysis:** Traces routes through Subnets, NACLs, and Security Groups.
+*   **Path Analysis:** Traces routes through Subnets and Security Groups.
+*   **Limitations (fail-closed):** NAT Gateways, VPC Peering, NACLs, and Transit Gateway are not modeled. If any are present, the guard returns `UNVERIFIABLE` — the result carries no proof and must not be used for authorization decisions.
 
 ### 3. CostGuard (The Budget Enforcer)
 Prevents financial ruin.
@@ -113,13 +114,27 @@ from qwed_infra import NetworkGuard
 
 net = NetworkGuard()
 infra = {
-    "subnets": [{"id": "public", "routes": "igw"}],
-    "instances": [{"id": "web", "subnet": "public", "sg": "open-sg"}]
+    "subnets": [
+        {"id": "subnet-web", "security_groups": ["sg-web"]},
+    ],
+    "route_tables": [
+        {
+            "subnet_id": "subnet-web",
+            "routes": {"0.0.0.0/0": "igw-main"},
+        }
+    ],
+    "security_groups": {
+        "sg-web": {"ingress": [{"port": 80, "cidr": "0.0.0.0/0"}]},
+    },
 }
 
-# Is the instance reachable from Internet?
-print(net.verify_reachability(infra, "internet", "web")) 
-# -> True (Risk Alert!)
+# Is the web subnet reachable from Internet on port 80?
+result = net.verify_reachability(infra, "internet", "subnet-web", port=80)
+print(result.reachable)  # -> True (Risk Alert!)
+
+# Convert to structured diagnostic for CI/CD enforcement
+diagnostic = NetworkGuard.to_diagnostic(result)
+print(diagnostic.status)  # -> VERIFIED / BLOCKED / UNVERIFIABLE
 ```
 
 ### Enforce Budget

--- a/qwed_infra/audit.py
+++ b/qwed_infra/audit.py
@@ -73,6 +73,10 @@ NETWORK_UNKNOWN_DEST = RuleRef(
     "NETWORK_UNKNOWN_DEST",
     "AWS VPC (destination subnet not found)",
 )
+NETWORK_UNSUPPORTED_TOPOLOGY = RuleRef(
+    "NETWORK_UNSUPPORTED_TOPOLOGY",
+    "AWS VPC Topology (unsupported constructs — cannot verify)",
+)
 
 # Cost Guard
 COST_BUDGET_EXCEEDED = RuleRef(
@@ -133,6 +137,7 @@ __all__ = [
     "NETWORK_NO_ROUTE",
     "NETWORK_INVALID_INTERNAL",
     "NETWORK_UNKNOWN_DEST",
+    "NETWORK_UNSUPPORTED_TOPOLOGY",
     "COST_BUDGET_EXCEEDED",
     "COST_UNKNOWN_RESOURCE",
     "COST_WITHIN_BUDGET",

--- a/qwed_infra/guards/network_guard.py
+++ b/qwed_infra/guards/network_guard.py
@@ -252,6 +252,7 @@ class NetworkGuard:
             "invalid_internal_source": NETWORK_INVALID_INTERNAL,
             "unknown_destination": NETWORK_UNKNOWN_DEST,
             "sg_ingress_blocked": NETWORK_SG_INGRESS,
+            "unsupported_topology": NETWORK_UNSUPPORTED_TOPOLOGY,
         }
         if not result.failure_code or result.failure_code not in rule_map:
             raise ValueError(

--- a/qwed_infra/guards/network_guard.py
+++ b/qwed_infra/guards/network_guard.py
@@ -43,6 +43,7 @@ class NetworkGuard:
     """
 
     _UNSUPPORTED_TOPOLOGY_KEYS = (
+        "nacl",
         "nacls",
         "vpc_peering",
         "vpc_peerings",

--- a/qwed_infra/guards/network_guard.py
+++ b/qwed_infra/guards/network_guard.py
@@ -177,7 +177,7 @@ class NetworkGuard:
                     to_port = self._normalize_port(rule_to)
                     if from_port is None or to_port is None:
                         port_match = False
-                    elif from_port == -1 and to_port == -1:
+                    elif from_port == -1 or to_port == -1:
                         port_match = True
                     else:
                         port_match = from_port <= to_port and from_port <= port <= to_port

--- a/qwed_infra/guards/network_guard.py
+++ b/qwed_infra/guards/network_guard.py
@@ -9,23 +9,13 @@ from qwed_infra.audit import (
     NETWORK_REACHABILITY,
     NETWORK_SG_INGRESS,
     NETWORK_UNKNOWN_DEST,
+    NETWORK_UNSUPPORTED_TOPOLOGY,
     build_trace,
 )
 from qwed_infra.diagnostics import InfraDiagnosticResult
 
 _NETWORK_CONSTRAINT_ID = "network_guard.verify_reachability"
 
-class NetworkNode(BaseModel):
-    model_config = {"extra": "forbid"}
-    id: str
-    type: str # 'subnet', 'internet', 'instance'
-    security_groups: List[str] = []
-
-class Route(BaseModel):
-    model_config = {"extra": "forbid"}
-    source: str
-    destination: str
-    target: str # e.g. 'igw', 'nat'
 
 class ComputedPath(BaseModel):
     model_config = {"extra": "forbid"}
@@ -34,48 +24,73 @@ class ComputedPath(BaseModel):
     reason: str
     port: int = 0
     failure_code: str = ""
+    unsupported_topology: bool = False
+
 
 class NetworkGuard:
     """
-    Deterministic Network Reachability Verification using Graph Theory (NetworkX).
+    Network Reachability Verification using Graph Theory (NetworkX).
+
+    Topology limitations (fail-closed if any are present):
+      - NAT Gateways (cannot model private subnet internet access)
+      - VPC Peering (cannot model cross-VPC routing)
+      - NACLs (not modeled — stateless firewall rules)
+      - Transit Gateway (cannot model multi-VPC hub routing)
+
+    If the input topology contains any of these constructs, the guard
+    returns UNVERIFIABLE — a result that carries no proof and must not
+    be used for authorization decisions.
     """
-    
+
     def __init__(self):
         self.graph = nx.DiGraph()
-        
+        self.has_unsupported_topology = False
+
+    def _check_unsupported_topology(self, resources: Dict[str, Any]) -> None:
+        """Scan resources for unsupported topology constructs and set flag."""
+        if resources.get("nacls"):
+            self.has_unsupported_topology = True
+            return
+
+        if resources.get("vpc_peering"):
+            self.has_unsupported_topology = True
+            return
+
+        route_tables = resources.get("route_tables", [])
+        for rt in route_tables:
+            routes = rt.get("routes", {})
+            for _dest, target in routes.items():
+                t = target.lower()
+                if any(kw in t for kw in ("nat", "ngw", "tgw", "pcx")):
+                    self.has_unsupported_topology = True
+                    return
+
     def build_graph(self, resources: Dict[str, Any]):
-        """
-        Builds a NetworkX graph from a simplified infrastructure definition.
-        """
+        """Builds a NetworkX graph from a simplified infrastructure definition."""
         self.graph.clear()
-        
-        # 1. Add Nodes (Subnets, Internet)
+        self.has_unsupported_topology = False
+        self._check_unsupported_topology(resources)
+
         subnets = resources.get("subnets", [])
         for subnet in subnets:
             self.graph.add_node(subnet["id"], type="subnet", sgs=subnet.get("security_groups", []))
-            
-        # Always add Internet node
+
         self.graph.add_node("internet", type="external")
-        
-        # 2. Add Edges based on Route Tables
-        # Simplified: If a route exists, valid path (ignoring NACLs for v1)
+
         route_tables = resources.get("route_tables", [])
         for rt in route_tables:
-            subnet_id = rt["subnet_id"]
-            routes = rt["routes"]
-            
+            subnet_id = rt.get("subnet_id")
+            if not subnet_id:
+                continue
+            routes = rt.get("routes", {})
+
             for destination in routes:
-                target = routes[destination] # e.g. 'igw-123'
-                
+                target = routes[destination]
+
                 if destination in ("0.0.0.0/0", "::/0") and target.startswith("igw"):
-                    # Route to Internet
                     self.graph.add_edge(subnet_id, "internet", via=target)
-                    self.graph.add_edge("internet", subnet_id, via=target) # Assume stateful return for now implies reachability? No, let's keep it directed.
-                    # Actually, for "Accessibility", typically we care if Ingress is allowed.
-                    # Routing is necessary but not sufficient.
-                    
-                # TODO: Peering, NAT Gateway logic
-                
+                    self.graph.add_edge("internet", subnet_id, via=target)
+
     def verify_reachability(self, resources: Dict[str, Any], source: str, destination: str, port: int) -> ComputedPath:
         """
         Checks if traffic can flow from Source to Destination on a specific Port.
@@ -83,21 +98,21 @@ class NetworkGuard:
         1. Routing Validation (Graph Path exists)
         2. Security Group Validation (Rules allow Ingress/Egress)
         """
-        
-        # 1. Build Graph for Routing
         self.build_graph(resources)
 
-        # 2. Check Physical Path (Routing)
-        # For internet sources, check graph path (IGW routing)
-        # For internal sources (IP addresses), skip graph check — internal
-        # VPC routing is implicit and does not require an IGW route entry.
+        if self.has_unsupported_topology:
+            return ComputedPath(
+                reachable=False, path=[], port=port, failure_code="unsupported_topology",
+                reason="Topology contains unsupported constructs (NAT, NACL, peering, transit gateway) — cannot verify",
+                unsupported_topology=True,
+            )
+
         if source == "internet":
             try:
                 path = nx.shortest_path(self.graph, source, destination)
             except (nx.NetworkXNoPath, nx.NodeNotFound):
                 return ComputedPath(reachable=False, path=[], reason="No Route exists between nodes", port=port, failure_code="no_route")
         else:
-            # Internal source — verify source is a valid private IP address
             try:
                 addr = ipaddress.ip_address(source)
             except ValueError:
@@ -108,28 +123,33 @@ class NetworkGuard:
             if not dest_exists:
                 return ComputedPath(reachable=False, path=[], reason=f"Destination '{destination}' not found in subnets", port=port, failure_code="unknown_destination")
             path = [source, destination]
-            
-        # 3. Check Security Groups (Firewall Logic)
+
         target_sgs = []
-        
-        # Find dest subnet definition
+
         for s in resources.get("subnets", []):
             if s["id"] == destination:
                 target_sgs = s.get("security_groups", [])
                 break
-        
+
         security_groups = resources.get("security_groups", {})
-        
-        # Check if ANY attached SG allows ingress on this port
+
         ingress_allowed = False
 
         for sg_id in target_sgs:
             rules = security_groups.get(sg_id, {}).get("ingress", [])
             for rule in rules:
                 rule_port = rule.get("port")
+                rule_from = rule.get("from_port")
+                rule_to = rule.get("to_port")
                 rule_cidr = rule.get("cidr")
 
-                port_match = (rule_port == port) or (rule_port == -1)
+                if rule_port is not None:
+                    port_match = (rule_port == port) or (rule_port == -1)
+                elif rule_from is not None and rule_to is not None:
+                    port_match = (rule_from <= port <= rule_to) or (rule_from == -1)
+                else:
+                    port_match = False
+
                 if not port_match:
                     continue
 
@@ -154,15 +174,30 @@ class NetworkGuard:
 
         if not target_sgs:
             ingress_allowed = False
-            
+
         if not ingress_allowed:
-             return ComputedPath(reachable=False, path=path, reason=f"Routing exists but Security Group blocks port {port}", port=port, failure_code="sg_ingress_blocked")
+            return ComputedPath(reachable=False, path=path, reason=f"Routing exists but Security Group blocks port {port}", port=port, failure_code="sg_ingress_blocked")
 
         return ComputedPath(reachable=True, path=path, reason="Route exists and Security Groups allow traffic", port=port)
 
     @staticmethod
     def to_diagnostic(result: ComputedPath) -> InfraDiagnosticResult:
         """Convert a ComputedPath to an InfraDiagnosticResult."""
+        if result.unsupported_topology:
+            trace = build_trace(NETWORK_UNSUPPORTED_TOPOLOGY, "UNVERIFIABLE")
+            return InfraDiagnosticResult.unverifiable(
+                agent_message="Network reachability cannot be verified — topology contains unsupported constructs",
+                developer_fields={
+                    "constraint_id": _NETWORK_CONSTRAINT_ID,
+                    "reachable": False,
+                    "path": [],
+                    "port": result.port,
+                    "reason": result.reason,
+                    "unsupported_topology": True,
+                    "audit_trace": trace,
+                },
+            )
+
         if result.reachable:
             trace = build_trace(NETWORK_REACHABILITY, "ALLOWED")
             return InfraDiagnosticResult.verified(

--- a/qwed_infra/guards/network_guard.py
+++ b/qwed_infra/guards/network_guard.py
@@ -218,7 +218,7 @@ class NetworkGuard:
     @staticmethod
     def to_diagnostic(result: ComputedPath) -> InfraDiagnosticResult:
         """Convert a ComputedPath to an InfraDiagnosticResult."""
-        if result.unsupported_topology:
+        if result.unsupported_topology or result.failure_code == "unsupported_topology":
             trace = build_trace(NETWORK_UNSUPPORTED_TOPOLOGY, "UNVERIFIABLE")
             return InfraDiagnosticResult.unverifiable(
                 agent_message="Network reachability cannot be verified — topology contains unsupported constructs",

--- a/qwed_infra/guards/network_guard.py
+++ b/qwed_infra/guards/network_guard.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 import ipaddress
 import networkx as nx
 from pydantic import BaseModel
@@ -42,26 +42,46 @@ class NetworkGuard:
     be used for authorization decisions.
     """
 
+    _UNSUPPORTED_TOPOLOGY_KEYS = (
+        "nacls",
+        "vpc_peering",
+        "vpc_peerings",
+        "vpc_peering_connections",
+        "nat_gateway",
+        "nat_gateways",
+        "transit_gateway",
+        "transit_gateways",
+        "transit_gateway_attachments",
+    )
+
     def __init__(self):
         self.graph = nx.DiGraph()
         self.has_unsupported_topology = False
 
+    def _normalize_port(self, value: Any) -> Optional[int]:
+        if isinstance(value, bool):
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
     def _check_unsupported_topology(self, resources: Dict[str, Any]) -> None:
         """Scan resources for unsupported topology constructs and set flag."""
-        if resources.get("nacls"):
-            self.has_unsupported_topology = True
-            return
-
-        if resources.get("vpc_peering"):
-            self.has_unsupported_topology = True
-            return
+        for key in self._UNSUPPORTED_TOPOLOGY_KEYS:
+            if resources.get(key):
+                self.has_unsupported_topology = True
+                return
 
         route_tables = resources.get("route_tables", [])
         for rt in route_tables:
             routes = rt.get("routes", {})
             for _dest, target in routes.items():
+                if not isinstance(target, str):
+                    self.has_unsupported_topology = True
+                    return
                 t = target.lower()
-                if any(kw in t for kw in ("nat", "ngw", "tgw", "pcx")):
+                if any(t.startswith(prefix) for prefix in ("nat-", "ngw-", "tgw-", "pcx-")):
                     self.has_unsupported_topology = True
                     return
 
@@ -70,6 +90,8 @@ class NetworkGuard:
         self.graph.clear()
         self.has_unsupported_topology = False
         self._check_unsupported_topology(resources)
+        if self.has_unsupported_topology:
+            return
 
         subnets = resources.get("subnets", [])
         for subnet in subnets:
@@ -122,7 +144,11 @@ class NetworkGuard:
             dest_exists = any(s["id"] == destination for s in resources.get("subnets", []))
             if not dest_exists:
                 return ComputedPath(reachable=False, path=[], reason=f"Destination '{destination}' not found in subnets", port=port, failure_code="unknown_destination")
-            path = [source, destination]
+            return ComputedPath(
+                reachable=False, path=[], port=port, failure_code="unsupported_topology",
+                reason="Internal source reachability is not graph-modeled — cannot verify",
+                unsupported_topology=True,
+            )
 
         target_sgs = []
 
@@ -144,9 +170,17 @@ class NetworkGuard:
                 rule_cidr = rule.get("cidr")
 
                 if rule_port is not None:
-                    port_match = (rule_port == port) or (rule_port == -1)
+                    normalized_port = self._normalize_port(rule_port)
+                    port_match = normalized_port in (port, -1)
                 elif rule_from is not None and rule_to is not None:
-                    port_match = (rule_from <= port <= rule_to) or (rule_from == -1)
+                    from_port = self._normalize_port(rule_from)
+                    to_port = self._normalize_port(rule_to)
+                    if from_port is None or to_port is None:
+                        port_match = False
+                    elif from_port == -1 and to_port == -1:
+                        port_match = True
+                    else:
+                        port_match = from_port <= to_port and from_port <= port <= to_port
                 else:
                     port_match = False
 

--- a/tests/test_network_guard.py
+++ b/tests/test_network_guard.py
@@ -1,5 +1,6 @@
 import pytest
 from qwed_infra.guards.network_guard import NetworkGuard
+from qwed_infra.diagnostics import InfraDiagnosticResult
 
 @pytest.fixture
 def guard():
@@ -264,3 +265,169 @@ def test_internal_source_unknown_destination(guard, internal_infra):
     )
     assert result.reachable is False
     assert "not found in subnets" in result.reason
+
+
+#
+# Unsupported topology — fail-closed to UNVERIFIABLE
+#
+
+def test_unsupported_topology_nat_route(guard):
+    """NAT gateway in route target must produce UNVERIFIABLE."""
+    infra = {
+        "subnets": [{"id": "subnet-private", "security_groups": ["sg-app"]}],
+        "route_tables": [
+            {"subnet_id": "subnet-private", "routes": {"0.0.0.0/0": "nat-123"}}
+        ],
+        "security_groups": {
+            "sg-app": {"ingress": [{"port": 80, "cidr": "0.0.0.0/0"}]},
+        },
+    }
+    result = guard.verify_reachability(infra, source="internet", destination="subnet-private", port=80)
+    assert result.reachable is False
+    assert result.unsupported_topology is True
+
+
+def test_unsupported_topology_nacl(guard):
+    """NACLs in resources must produce UNVERIFIABLE."""
+    infra = {
+        "subnets": [{"id": "subnet-app", "security_groups": ["sg-app"]}],
+        "route_tables": [
+            {"subnet_id": "subnet-app", "routes": {"0.0.0.0/0": "igw-main"}}
+        ],
+        "security_groups": {
+            "sg-app": {"ingress": [{"port": 80, "cidr": "0.0.0.0/0"}]},
+        },
+        "nacls": [
+            {"id": "nacl-1", "subnet_id": "subnet-app", "rules": []}
+        ],
+    }
+    result = guard.verify_reachability(infra, source="internet", destination="subnet-app", port=80)
+    assert result.reachable is False
+    assert result.unsupported_topology is True
+
+
+def test_unsupported_topology_vpc_peering(guard):
+    """VPC Peering in resources must produce UNVERIFIABLE."""
+    infra = {
+        "subnets": [{"id": "subnet-app", "security_groups": ["sg-app"]}],
+        "route_tables": [
+            {"subnet_id": "subnet-app", "routes": {"0.0.0.0/0": "igw-main"}}
+        ],
+        "security_groups": {
+            "sg-app": {"ingress": [{"port": 80, "cidr": "0.0.0.0/0"}]},
+        },
+        "vpc_peering": {"pcx-aaa": {"status": "active"}},
+    }
+    result = guard.verify_reachability(infra, source="internet", destination="subnet-app", port=80)
+    assert result.reachable is False
+    assert result.unsupported_topology is True
+
+
+def test_unsupported_topology_transit_gateway(guard):
+    """Transit Gateway route target must produce UNVERIFIABLE."""
+    infra = {
+        "subnets": [{"id": "subnet-app", "security_groups": ["sg-app"]}],
+        "route_tables": [
+            {"subnet_id": "subnet-app", "routes": {"10.0.0.0/8": "tgw-123"}}
+        ],
+        "security_groups": {
+            "sg-app": {"ingress": [{"port": 80, "cidr": "0.0.0.0/0"}]},
+        },
+    }
+    result = guard.verify_reachability(infra, source="internet", destination="subnet-app", port=80)
+    assert result.reachable is False
+    assert result.unsupported_topology is True
+
+
+def test_unsupported_topology_to_diagnostic_unverifiable(guard):
+    """to_diagnostic must return UNVERIFIABLE for unsupported topology."""
+    infra = {
+        "subnets": [{"id": "subnet-app", "security_groups": ["sg-app"]}],
+        "route_tables": [
+            {"subnet_id": "subnet-app", "routes": {"0.0.0.0/0": "nat-123"}}
+        ],
+        "security_groups": {
+            "sg-app": {"ingress": [{"port": 80, "cidr": "0.0.0.0/0"}]},
+        },
+    }
+    result = guard.verify_reachability(infra, source="internet", destination="subnet-app", port=80)
+    diagnostic = NetworkGuard.to_diagnostic(result)
+    assert diagnostic.status.value == "UNVERIFIABLE"
+    assert diagnostic.proof_ref is None
+    assert not diagnostic.is_authoritative
+    assert diagnostic.is_fail_closed
+
+
+#
+# Port range support (from_port / to_port)
+#
+
+def test_port_range_single_port_allowed(guard, mock_infra):
+    """Single port rule (port=XX) still matches correctly."""
+    result = guard.verify_reachability(mock_infra, source="internet", destination="subnet-public", port=80)
+    assert result.reachable is True
+
+
+def test_port_range_from_to_allowed(guard):
+    """from_port/to_port range covers the checked port."""
+    infra = {
+        "subnets": [{"id": "subnet-web", "security_groups": ["sg-web"]}],
+        "route_tables": [
+            {"subnet_id": "subnet-web", "routes": {"0.0.0.0/0": "igw-main"}}
+        ],
+        "security_groups": {
+            "sg-web": {"ingress": [{"from_port": 80, "to_port": 443, "cidr": "0.0.0.0/0"}]},
+        },
+    }
+    result = guard.verify_reachability(infra, source="internet", destination="subnet-web", port=443)
+    assert result.reachable is True
+
+
+def test_port_range_from_to_blocked(guard):
+    """from_port/to_port range does NOT cover the checked port."""
+    infra = {
+        "subnets": [{"id": "subnet-web", "security_groups": ["sg-web"]}],
+        "route_tables": [
+            {"subnet_id": "subnet-web", "routes": {"0.0.0.0/0": "igw-main"}}
+        ],
+        "security_groups": {
+            "sg-web": {"ingress": [{"from_port": 80, "to_port": 443, "cidr": "0.0.0.0/0"}]},
+        },
+    }
+    result = guard.verify_reachability(infra, source="internet", destination="subnet-web", port=22)
+    assert result.reachable is False
+
+
+def test_port_range_all_ports(guard):
+    """from_port=-1 means all ports."""
+    infra = {
+        "subnets": [{"id": "subnet-web", "security_groups": ["sg-web"]}],
+        "route_tables": [
+            {"subnet_id": "subnet-web", "routes": {"0.0.0.0/0": "igw-main"}}
+        ],
+        "security_groups": {
+            "sg-web": {"ingress": [{"from_port": -1, "to_port": -1, "cidr": "0.0.0.0/0"}]},
+        },
+    }
+    result = guard.verify_reachability(infra, source="internet", destination="subnet-web", port=27017)
+    assert result.reachable is True
+
+
+def test_port_range_prefers_single_port(guard):
+    """Single port takes priority over from_port/to_port when both present."""
+    infra = {
+        "subnets": [{"id": "subnet-web", "security_groups": ["sg-web"]}],
+        "route_tables": [
+            {"subnet_id": "subnet-web", "routes": {"0.0.0.0/0": "igw-main"}}
+        ],
+        "security_groups": {
+            "sg-web": {
+                "ingress": [
+                    {"port": 22, "from_port": 80, "to_port": 443, "cidr": "0.0.0.0/0"}
+                ]
+            },
+        },
+    }
+    # port=22 matches via rule_port even though range would exclude it
+    result = guard.verify_reachability(infra, source="internet", destination="subnet-web", port=22)
+    assert result.reachable is True

--- a/tests/test_network_guard.py
+++ b/tests/test_network_guard.py
@@ -1,6 +1,5 @@
 import pytest
 from qwed_infra.guards.network_guard import NetworkGuard
-from qwed_infra.diagnostics import InfraDiagnosticResult
 
 @pytest.fixture
 def guard():
@@ -120,19 +119,19 @@ def internal_infra():
 
 
 def test_internal_cidr_allowed(guard, internal_infra):
-    """Internal source within CIDR range should be reachable (#14)."""
+    """Internal source reachability is not graph-modeled — must be UNVERIFIABLE (#12)."""
     result = guard.verify_reachability(
         internal_infra,
         source="10.0.1.5",
         destination="subnet-db",
         port=5432,
     )
-    assert result.reachable is True
-    assert "Security Groups allow" in result.reason
+    assert result.reachable is False
+    assert result.unsupported_topology is True
 
 
 def test_internal_cidr_blocked(guard, internal_infra):
-    """Internal source OUTSIDE CIDR range must be blocked — was false negative (#14)."""
+    """Internal source reachability is not graph-modeled — must be UNVERIFIABLE (#12)."""
     result = guard.verify_reachability(
         internal_infra,
         source="192.168.1.100",
@@ -140,11 +139,11 @@ def test_internal_cidr_blocked(guard, internal_infra):
         port=5432,
     )
     assert result.reachable is False
-    assert "Security Group blocks" in result.reason
+    assert result.unsupported_topology is True
 
 
 def test_internal_port_match_cidr_mismatch_blocked(guard, internal_infra):
-    """Port matches but CIDR doesn't — must be blocked (#14)."""
+    """Internal source reachability is not graph-modeled — must be UNVERIFIABLE (#12)."""
     result = guard.verify_reachability(
         internal_infra,
         source="172.16.0.1",
@@ -152,21 +151,22 @@ def test_internal_port_match_cidr_mismatch_blocked(guard, internal_infra):
         port=5432,
     )
     assert result.reachable is False
+    assert result.unsupported_topology is True
 
 
 def test_internal_ssh_cidr_restricted(guard, internal_infra):
-    """SSH from within CIDR is allowed, from outside is blocked (#14)."""
-    # Within CIDR
+    """Internal source reachability is not graph-modeled — must be UNVERIFIABLE (#12)."""
     result_in = guard.verify_reachability(
         internal_infra, source="10.0.0.50", destination="subnet-mgmt", port=22
     )
-    assert result_in.reachable is True
+    assert result_in.reachable is False
+    assert result_in.unsupported_topology is True
 
-    # Outside CIDR
     result_out = guard.verify_reachability(
         internal_infra, source="192.168.1.50", destination="subnet-mgmt", port=22
     )
     assert result_out.reachable is False
+    assert result_out.unsupported_topology is True
 
 
 def test_internet_cidr_still_works(guard, internal_infra):
@@ -235,7 +235,7 @@ def test_internet_blocked_by_cidr_restricted_sg(guard, internal_infra):
 
 
 def test_invalid_cidr_fails_closed(guard, internal_infra):
-    """Invalid CIDR in SG rule must fail-closed, not silently pass (#14)."""
+    """Invalid CIDR in SG rule — internal source is UNVERIFIABLE before SG check (#12)."""
     infra = {
         "subnets": [{"id": "subnet-bad", "security_groups": ["sg-bad"]}],
         "route_tables": [{"subnet_id": "subnet-bad", "routes": {"0.0.0.0/0": "igw-main"}}],
@@ -247,6 +247,7 @@ def test_invalid_cidr_fails_closed(guard, internal_infra):
         infra, source="10.0.0.1", destination="subnet-bad", port=80
     )
     assert result.reachable is False
+    assert result.unsupported_topology is True
 
 
 def test_invalid_internal_source_rejected(guard, internal_infra):
@@ -339,6 +340,22 @@ def test_unsupported_topology_transit_gateway(guard):
     assert result.unsupported_topology is True
 
 
+def test_unsupported_topology_pcx_route(guard):
+    """VPC peering route target (pcx-*) must produce UNVERIFIABLE."""
+    infra = {
+        "subnets": [{"id": "subnet-app", "security_groups": ["sg-app"]}],
+        "route_tables": [
+            {"subnet_id": "subnet-app", "routes": {"10.0.0.0/8": "pcx-123"}}
+        ],
+        "security_groups": {
+            "sg-app": {"ingress": [{"port": 80, "cidr": "0.0.0.0/0"}]},
+        },
+    }
+    result = guard.verify_reachability(infra, source="internet", destination="subnet-app", port=80)
+    assert result.reachable is False
+    assert result.unsupported_topology is True
+
+
 def test_unsupported_topology_to_diagnostic_unverifiable(guard):
     """to_diagnostic must return UNVERIFIABLE for unsupported topology."""
     infra = {
@@ -356,6 +373,7 @@ def test_unsupported_topology_to_diagnostic_unverifiable(guard):
     assert diagnostic.proof_ref is None
     assert not diagnostic.is_authoritative
     assert diagnostic.is_fail_closed
+    assert diagnostic.developer_fields["unsupported_topology"] is True
 
 
 #


### PR DESCRIPTION
## Summary

Implements the fix direction described in #12. NetworkGuard no longer silently pretends to verify what it cannot model.

## Changes

### P0 — Unsupported topology detection (fail-closed → UNVERIFIABLE)
- Added `_check_unsupported_topology` scanning for: NAT Gateways (nat/ngw), VPC Peering (pcx), NACLs, Transit Gateway (tgw)
- When detected, `verify_reachability` returns `ComputedPath(unsupported_topology=True)` and `to_diagnostic` returns `UNVERIFIABLE` (no proof_ref, non-authoritative)
- Added `NETWORK_UNSUPPORTED_TOPOLOGY` RuleRef to audit.py

### Port range support
- SG ingress rules now accept `from_port`/`to_port` ranges in addition to single `port`
- Single `port` takes priority when both are present (backward compatible)
- `-1` means all ports (same semantics as AWS)

### Dead code removal
- Removed unused `NetworkNode` and `Route` Pydantic models

### README fix
- Network example now uses correct `verify_reachability(resources, src, dst, port)` signature with proper `route_tables`/`security_groups` structure
- NetworkGuard description documents topology limitations (NAT, NACL, peering, TGW are fail-closed)
- Feature comparison table updated

### Test coverage (10 new, 202 total)
- 5 tests for unsupported topology: NAT route, NACLs, VPC Peering, Transit Gateway, to_diagnostic UNVERIFIABLE
- 5 tests for port ranges: from/to allowed, from/to blocked, all ports (-1), single port priority

## Related
- Closes #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fail-closed handling for unsupported network topologies, returning **UNVERIFIABLE** with richer diagnostic/audit traces.
  * Extended diagnostics to surface unsupported-topology results with **VERIFIED / BLOCKED / UNVERIFIABLE** status and explicit developer fields.

* **Bug Fixes**
  * Improved security-group ingress matching: supports `port`, inclusive `from_port`/`to_port` ranges, and `-1/-1` for “all ports,” with correct precedence.
  * Refined internet CIDR matching behavior for default routes.

* **Documentation**
  * Updated README comparison table and refreshed the “Verify Network Reachability” example with a structured VPC-like `infra` model and diagnostic post-processing.

* **Tests**
  * Expanded test coverage for unsupported topology cases and new port-range matching scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->