### PR TITLE
fix #11: CostGuard remove implicit instance_type defaults, fail-closed on missing type

### DIFF
--- a/qwed_infra/guards/cost_guard.py
+++ b/qwed_infra/guards/cost_guard.py
@@ -55,6 +55,13 @@ class CostGuard:
     HOURS_PER_MONTH = 730
 
     @staticmethod
+    def _unique_key(breakdown: dict, key: str) -> str:
+        if key not in breakdown:
+            return key
+        suffix = sum(1 for k in breakdown if k == key or k.startswith(f"{key}#"))
+        return f"{key}#{suffix}"
+
+    @staticmethod
     def _build_reason(
         total_monthly: float,
         budget_monthly: float,
@@ -105,7 +112,8 @@ class CostGuard:
 
             cost = price * count
             total_hourly_cost += cost
-            breakdown[inst.get('id', inst_type)] = cost * self.HOURS_PER_MONTH
+            key = self._unique_key(breakdown, inst.get('id') or inst_type)
+            breakdown[key] = cost * self.HOURS_PER_MONTH
 
         volumes = resources.get("volumes", [])
         for vol in volumes:
@@ -123,7 +131,8 @@ class CostGuard:
                 continue
             cost = size_gb * price_per_gb_hour
             total_hourly_cost += cost
-            breakdown[f"vol-{vol.get('id', 'unknown')}"] = cost * self.HOURS_PER_MONTH
+            key = self._unique_key(breakdown, f"vol-{vol.get('id', 'unknown')}")
+            breakdown[key] = cost * self.HOURS_PER_MONTH
 
         total_monthly = total_hourly_cost * self.HOURS_PER_MONTH
         has_unknown = bool(unknown_instance_types) or bool(unknown_volume_types)

--- a/qwed_infra/guards/cost_guard.py
+++ b/qwed_infra/guards/cost_guard.py
@@ -89,54 +89,60 @@ class CostGuard:
             False,
         )
 
+    def _process_instance(
+        self, inst: dict, breakdown: dict, unknown_instance_types: list
+    ) -> float:
+        inst_type = inst.get("instance_type")
+        if inst_type is None:
+            inst_id = inst.get("id") or "<missing-id>"
+            key = self._unique_key(breakdown, f"unknown-{inst_id}")
+            breakdown[key] = 0.0
+            unknown_instance_types.append("<missing>")
+            return 0.0
+        count = inst.get("count", 1)
+        price = self.PRICING_CATALOG.get(inst_type)
+        if price is None:
+            key = self._unique_key(breakdown, f"unknown-{inst.get('id') or inst_type}")
+            breakdown[key] = 0.0
+            unknown_instance_types.append(inst_type)
+            return 0.0
+        cost = price * count
+        key = self._unique_key(breakdown, inst.get('id') or inst_type)
+        breakdown[key] = cost * self.HOURS_PER_MONTH
+        return cost
+
+    def _process_volume(
+        self, vol: dict, breakdown: dict, unknown_volume_types: list
+    ) -> float:
+        vol_type = vol.get("volume_type")
+        size_gb = vol.get("size_gb", 10)
+        if vol_type is None:
+            key = self._unique_key(breakdown, f"unknown-{vol.get('id') or 'missing-volume-type'}")
+            breakdown[key] = 0.0
+            unknown_volume_types.append("<missing>")
+            return 0.0
+        key = f"{vol_type}-storage-gb"
+        price_per_gb_hour = self.PRICING_CATALOG.get(key)
+        if price_per_gb_hour is None:
+            key = self._unique_key(breakdown, f"unknown-{vol.get('id') or vol_type}")
+            breakdown[key] = 0.0
+            unknown_volume_types.append(vol_type)
+            return 0.0
+        cost = size_gb * price_per_gb_hour
+        key = self._unique_key(breakdown, f"vol-{vol.get('id', 'unknown')}")
+        breakdown[key] = cost * self.HOURS_PER_MONTH
+        return cost
+
     def verify_budget(self, resources: Dict[str, Any], budget_monthly: float) -> CostEstimate:
         total_hourly_cost = 0.0
         breakdown = {}
         unknown_instance_types = []
         unknown_volume_types = []
 
-        instances = resources.get("instances", [])
-        for inst in instances:
-            inst_type = inst.get("instance_type")
-            if inst_type is None:
-                inst_id = inst.get("id") or "<missing-id>"
-                key = self._unique_key(breakdown, f"unknown-{inst_id}")
-                breakdown[key] = 0.0
-                unknown_instance_types.append("<missing>")
-                continue
-            count = inst.get("count", 1)
-            price = self.PRICING_CATALOG.get(inst_type)
-            if price is None:
-                key = self._unique_key(breakdown, f"unknown-{inst.get('id') or inst_type}")
-                breakdown[key] = 0.0
-                unknown_instance_types.append(inst_type)
-                continue
-
-            cost = price * count
-            total_hourly_cost += cost
-            key = self._unique_key(breakdown, inst.get('id') or inst_type)
-            breakdown[key] = cost * self.HOURS_PER_MONTH
-
-        volumes = resources.get("volumes", [])
-        for vol in volumes:
-            vol_type = vol.get("volume_type")
-            size_gb = vol.get("size_gb", 10)
-            if vol_type is None:
-                key = self._unique_key(breakdown, f"unknown-{vol.get('id') or 'missing-volume-type'}")
-                breakdown[key] = 0.0
-                unknown_volume_types.append("<missing>")
-                continue
-            key = f"{vol_type}-storage-gb"
-            price_per_gb_hour = self.PRICING_CATALOG.get(key)
-            if price_per_gb_hour is None:
-                key = self._unique_key(breakdown, f"unknown-{vol.get('id') or vol_type}")
-                breakdown[key] = 0.0
-                unknown_volume_types.append(vol_type)
-                continue
-            cost = size_gb * price_per_gb_hour
-            total_hourly_cost += cost
-            key = self._unique_key(breakdown, f"vol-{vol.get('id', 'unknown')}")
-            breakdown[key] = cost * self.HOURS_PER_MONTH
+        for inst in resources.get("instances", []):
+            total_hourly_cost += self._process_instance(inst, breakdown, unknown_instance_types)
+        for vol in resources.get("volumes", []):
+            total_hourly_cost += self._process_volume(vol, breakdown, unknown_volume_types)
 
         total_monthly = total_hourly_cost * self.HOURS_PER_MONTH
         has_unknown = bool(unknown_instance_types) or bool(unknown_volume_types)

--- a/qwed_infra/guards/cost_guard.py
+++ b/qwed_infra/guards/cost_guard.py
@@ -90,7 +90,12 @@ class CostGuard:
 
         instances = resources.get("instances", [])
         for inst in instances:
-            inst_type = inst.get("instance_type", "t3.micro")
+            inst_type = inst.get("instance_type")
+            if inst_type is None:
+                inst_id = inst.get("id", "<missing-id>")
+                breakdown[f"unknown-{inst_id}"] = 0.0
+                unknown_instance_types.append("<missing>")
+                continue
             count = inst.get("count", 1)
             price = self.PRICING_CATALOG.get(inst_type)
             if price is None:
@@ -100,7 +105,7 @@ class CostGuard:
 
             cost = price * count
             total_hourly_cost += cost
-            breakdown[inst['id']] = cost * self.HOURS_PER_MONTH
+            breakdown[inst.get('id', inst_type)] = cost * self.HOURS_PER_MONTH
 
         volumes = resources.get("volumes", [])
         for vol in volumes:

--- a/qwed_infra/guards/cost_guard.py
+++ b/qwed_infra/guards/cost_guard.py
@@ -99,14 +99,16 @@ class CostGuard:
         for inst in instances:
             inst_type = inst.get("instance_type")
             if inst_type is None:
-                inst_id = inst.get("id", "<missing-id>")
-                breakdown[f"unknown-{inst_id}"] = 0.0
+                inst_id = inst.get("id") or "<missing-id>"
+                key = self._unique_key(breakdown, f"unknown-{inst_id}")
+                breakdown[key] = 0.0
                 unknown_instance_types.append("<missing>")
                 continue
             count = inst.get("count", 1)
             price = self.PRICING_CATALOG.get(inst_type)
             if price is None:
-                breakdown[f"unknown-{inst.get('id', inst_type)}"] = 0.0
+                key = self._unique_key(breakdown, f"unknown-{inst.get('id') or inst_type}")
+                breakdown[key] = 0.0
                 unknown_instance_types.append(inst_type)
                 continue
 
@@ -120,13 +122,15 @@ class CostGuard:
             vol_type = vol.get("volume_type")
             size_gb = vol.get("size_gb", 10)
             if vol_type is None:
-                breakdown[f"unknown-{vol.get('id', 'missing-volume-type')}"] = 0.0
+                key = self._unique_key(breakdown, f"unknown-{vol.get('id') or 'missing-volume-type'}")
+                breakdown[key] = 0.0
                 unknown_volume_types.append("<missing>")
                 continue
             key = f"{vol_type}-storage-gb"
             price_per_gb_hour = self.PRICING_CATALOG.get(key)
             if price_per_gb_hour is None:
-                breakdown[f"unknown-{vol.get('id', vol_type)}"] = 0.0
+                key = self._unique_key(breakdown, f"unknown-{vol.get('id') or vol_type}")
+                breakdown[key] = 0.0
                 unknown_volume_types.append(vol_type)
                 continue
             cost = size_gb * price_per_gb_hour

--- a/tests/test_cost_guard.py
+++ b/tests/test_cost_guard.py
@@ -151,3 +151,19 @@ def test_missing_both_id_and_type_fails_closed(guard):
     assert result.within_budget is False
     assert result.has_unknown_types is True
     assert "<missing>" in result.reason
+    assert "unknown-<missing-id>" in result.breakdown
+
+
+def test_id_less_instances_no_breakdown_collision(guard):
+    resources = {
+        "instances": [
+            {"instance_type": "t3.micro", "count": 2},
+            {"instance_type": "t3.micro", "count": 3},
+        ]
+    }
+    result = guard.verify_budget(resources, budget_monthly=100.0)
+    assert result.within_budget is True
+    assert "t3.micro" in result.breakdown
+    assert "t3.micro#1" in result.breakdown
+    assert result.breakdown["t3.micro"] == 2 * 0.0104 * 730
+    assert result.breakdown["t3.micro#1"] == 3 * 0.0104 * 730

--- a/tests/test_cost_guard.py
+++ b/tests/test_cost_guard.py
@@ -167,3 +167,51 @@ def test_id_less_instances_no_breakdown_collision(guard):
     assert "t3.micro#1" in result.breakdown
     assert result.breakdown["t3.micro"] == 2 * 0.0104 * 730
     assert result.breakdown["t3.micro#1"] == 3 * 0.0104 * 730
+
+
+def test_id_none_renders_as_missing_id(guard):
+    resources = {
+        "instances": [{"id": None}]
+    }
+    result = guard.verify_budget(resources, budget_monthly=100.0)
+    assert result.has_unknown_types is True
+    assert "unknown-<missing-id>" in result.breakdown
+
+
+def test_duplicate_unknown_instance_types_no_collision(guard):
+    resources = {
+        "instances": [
+            {"instance_type": "nonexistent-1x.small"},
+            {"instance_type": "nonexistent-1x.small"},
+        ]
+    }
+    result = guard.verify_budget(resources, budget_monthly=100.0)
+    assert result.has_unknown_types is True
+    assert "unknown-nonexistent-1x.small" in result.breakdown
+    assert "unknown-nonexistent-1x.small#1" in result.breakdown
+
+
+def test_duplicate_missing_volume_type_no_collision(guard):
+    resources = {
+        "volumes": [
+            {"size_gb": 10},
+            {"size_gb": 20},
+        ]
+    }
+    result = guard.verify_budget(resources, budget_monthly=100.0)
+    assert result.has_unknown_types is True
+    assert "unknown-missing-volume-type" in result.breakdown
+    assert "unknown-missing-volume-type#1" in result.breakdown
+
+
+def test_duplicate_unknown_volume_type_no_collision(guard):
+    resources = {
+        "volumes": [
+            {"volume_type": "nonexistent-storage", "size_gb": 10},
+            {"volume_type": "nonexistent-storage", "size_gb": 20},
+        ]
+    }
+    result = guard.verify_budget(resources, budget_monthly=100.0)
+    assert result.has_unknown_types is True
+    assert "unknown-nonexistent-storage" in result.breakdown
+    assert "unknown-nonexistent-storage#1" in result.breakdown

--- a/tests/test_cost_guard.py
+++ b/tests/test_cost_guard.py
@@ -116,3 +116,38 @@ def test_unknown_volume_type_to_diagnostic_blocked(guard):
     assert diagnostic.status.value == "BLOCKED"
     assert diagnostic.developer_fields["has_unknown_types"] is True
     assert diagnostic.developer_fields["audit_trace"]["rule_id"] == "COST_UNKNOWN_RESOURCE"
+
+
+def test_missing_instance_type_fails_closed(guard):
+    resources = {
+        "instances": [
+            {"id": "no-type-instance", "count": 1}
+        ]
+    }
+    result = guard.verify_budget(resources, budget_monthly=100.0)
+    assert result.within_budget is False
+    assert result.has_unknown_types is True
+    assert "<missing>" in result.reason
+    assert "unknown-no-type-instance" in result.breakdown
+
+
+def test_missing_instance_id_fails_closed(guard):
+    resources = {
+        "instances": [
+            {"instance_type": "nano.unknown"}
+        ]
+    }
+    result = guard.verify_budget(resources, budget_monthly=100.0)
+    assert result.within_budget is False
+    assert result.has_unknown_types is True
+    assert "unknown-nano.unknown" in result.breakdown
+
+
+def test_missing_both_id_and_type_fails_closed(guard):
+    resources = {
+        "instances": [{}]
+    }
+    result = guard.verify_budget(resources, budget_monthly=100.0)
+    assert result.within_budget is False
+    assert result.has_unknown_types is True
+    assert "<missing>" in result.reason


### PR DESCRIPTION
## Summary

CostGuard silently defaulted missing `instance_type` to "t3.micro" and used bare `inst['id']` (KeyError risk). Unknown infrastructure could become a concrete low-cost assumption.

## Changes

### Removed implicit instance_type default
- `inst.get("instance_type", "t3.micro")` → `inst.get("instance_type")`
- Missing `instance_type` now tracked in `unknown_instance_types` as `"<missing>"` and forces `within_budget=False` — same fail-closed pattern as unknown volume types

### Fixed inconsistent key access
- `inst['id']` → `inst.get('id', inst_type)` — consistent with unknown path, prevents KeyError on missing id

### Tests (3 new, 211 total)
- `test_missing_instance_type_fails_closed` — instance with no `instance_type`
- `test_missing_instance_id_fails_closed` — instance with no `id` but known unknown type
- `test_missing_both_id_and_type_fails_closed` — empty instance dict

## Related
- Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved budget checks to handle missing or unknown instance details more safely.
  * Unknown instances are now tracked explicitly instead of being treated as a default type.
  * Fixed duplicate cost breakdown entries so repeated resource names no longer overwrite each other.

* **Tests**
  * Added coverage for missing identifiers and duplicate resource keys to confirm the updated budget behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->