### PR TITLE
fix #18: README CostGuard example resources format, reason string, add README example validation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,11 +142,15 @@ print(diagnostic.status.value)  # -> VERIFIED / BLOCKED / UNVERIFIABLE
 from qwed_infra import CostGuard
 
 cost = CostGuard()
-resources = [{"type": "p4d.24xlarge", "count": 2}] # Expensive!
+resources = {
+    "instances": [
+        {"id": "gpu", "instance_type": "p4d.24xlarge", "count": 2}
+    ]
+}
 
 result = cost.verify_budget(resources, budget_monthly=1000)
 print(result.within_budget) # -> False
-print(result.reason) # -> "Est. $46,000 > Budget $1,000"
+print(result.reason) # -> "Estimated cost $47844.20 EXCEEDS budget $1000.00"
 ```
 
 ---

--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -21,7 +21,7 @@ def test_network_guard_readme_example():
     result = net.verify_reachability(infra, "internet", "subnet-web", port=80)
     assert result.reachable is True
     diagnostic = NetworkGuard.to_diagnostic(result)
-    assert diagnostic.status.value in ("VERIFIED", "BLOCKED", "UNVERIFIABLE")
+    assert diagnostic.status.value == "VERIFIED"
 
 
 def test_cost_guard_readme_example():

--- a/tests/test_readme_examples.py
+++ b/tests/test_readme_examples.py
@@ -1,0 +1,38 @@
+from qwed_infra.guards.network_guard import NetworkGuard
+from qwed_infra.guards.cost_guard import CostGuard
+
+
+def test_network_guard_readme_example():
+    net = NetworkGuard()
+    infra = {
+        "subnets": [
+            {"id": "subnet-web", "security_groups": ["sg-web"]},
+        ],
+        "route_tables": [
+            {
+                "subnet_id": "subnet-web",
+                "routes": {"0.0.0.0/0": "igw-main"},
+            }
+        ],
+        "security_groups": {
+            "sg-web": {"ingress": [{"port": 80, "cidr": "0.0.0.0/0"}]},
+        },
+    }
+    result = net.verify_reachability(infra, "internet", "subnet-web", port=80)
+    assert result.reachable is True
+    diagnostic = NetworkGuard.to_diagnostic(result)
+    assert diagnostic.status.value in ("VERIFIED", "BLOCKED", "UNVERIFIABLE")
+
+
+def test_cost_guard_readme_example():
+    cost = CostGuard()
+    resources = {
+        "instances": [
+            {"id": "gpu", "instance_type": "p4d.24xlarge", "count": 2}
+        ]
+    }
+    result = cost.verify_budget(resources, budget_monthly=1000)
+    assert result.within_budget is False
+    assert result.total_monthly_cost == "47844.20"
+    assert result.budget == "1000.00"
+    assert result.reason == "Estimated cost $47844.20 EXCEEDS budget $1000.00"


### PR DESCRIPTION
## Summary

Three issues in the README examples made them crash or produce wrong output for first-time users:

1. **CostGuard uses flat list instead of `{"instances": [...]}` dict** — `resources = [{"type": "p4d.24xlarge", "count": 2}]` raises `AttributeError: 'list' object has no attribute 'get'`
2. **CostGuard uses `"type"` key** instead of `"instance_type"` — silently treated as unknown type
3. **CostGuard reason string comment wrong** — showed `"Est. $46,000 > Budget $1,000"` but actual output is `"Estimated cost $47844.20 EXCEEDS budget $1000.00"` (with Decimal quantized format from #15)

## Changes

### README.md
- CostGuard example: `resources = [{"type": "p4d.24xlarge", "count": 2}]` → `{"instances": [{"id": "gpu", "instance_type": "p4d.24xlarge", "count": 2}]}`
- CostGuard reason comment: `"Est. $46,000 > Budget $1,000"` → `"Estimated cost $47844.20 EXCEEDS budget $1000.00"`
- NetworkGuard example was already correct (`port=80`, `"subnet-web"` fixed in prior PRs)

### New file: `tests/test_readme_examples.py`
- `test_network_guard_readme_example` — runs the NetworkGuard README code and asserts `reachable is True` + `to_diagnostic().status.value` in expected set
- `test_cost_guard_readme_example` — runs the CostGuard README code and asserts exact `within_budget`, `total_monthly_cost`, `budget`, and `reason` strings
- Prevents future drift between README examples and actual code behavior

## Related
- Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the budget-enforcement example in the README to use the latest input shape and cost message wording.
* **Tests**
  * Added readme-based checks for network reachability and budget verification examples.
  * Validated the expected diagnostic status values and the exact budget result, including the computed monthly cost and failure outcome.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->