### PR TITLE
fix #20: sonar version 1.0→0.1.0, python 3.10-3.12, remove dead requests dep, add project.urls, create CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## [0.1.0] - 2026-07-01
+
+### Added
+- IamGuard — Z3-based IAM policy verification (least privilege, condition evaluation)
+- NetworkGuard — NetworkX-based VPC reachability analysis with fail-closed on unsupported topologies (NAT, NACL, VPC peering, transit gateway)
+- CostGuard — Deterministic cost estimation with Decimal arithmetic, ROUND_HALF_UP quantization, fail-closed on unknown instance/volume types
+- Terraform parser — HCL2-based resource normalization with fail-closed on missing required fields
+- 3-layer diagnostic model — InfraDiagnosticResult with VERIFIED/BLOCKED/UNVERIFIABLE status, audit trace, and evidence
+- Numeric utilities — parse_decimal_input and decimal_text for exact financial computation (ported from qwed-tax v0.2.0)
+- CI/CD — Snyk, SonarCloud, GitHub Actions with fail-closed enforcement

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "z3-solver>=4.12.0",
     "networkx>=3.0",
     "pydantic>=2.0.0",
-    "requests>=2.31.0",
     "python-hcl2>=4.3.0",  # For parsing Terraform
 ]
 
@@ -22,6 +21,13 @@ dev = [
     "pytest-cov>=4.1.0",
     "black>=23.0.0",
 ]
+
+[project.urls]
+Homepage = "https://qwedai.com"
+Documentation = "https://docs.qwedai.com/infra"
+Repository = "https://github.com/QWED-AI/qwed-infra"
+Issues = "https://github.com/QWED-AI/qwed-infra/issues"
+Changelog = "https://github.com/QWED-AI/qwed-infra/blob/main/CHANGELOG.md"
 
 [build-system]
 requires = ["hatchling"]

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,14 +2,14 @@ sonar.projectKey=QWED-AI_qwed-infra
 sonar.organization=qwed-ai
 
 sonar.projectName=QWED Infra
-sonar.projectVersion=1.0
+sonar.projectVersion=0.1.0
 
 # Source directories
 sonar.sources=qwed_infra
 sonar.tests=tests
 
 # Python specific
-sonar.python.version=3.11
+sonar.python.version=3.10,3.11,3.12
 sonar.python.coverage.reportPaths=coverage.xml
 
 # Exclusions


### PR DESCRIPTION
## Summary

Three config issues found during the v0.2.0 qwed-tax audit cross-check. None affect runtime behavior, but all create misleading metadata or dead dependencies.

## Changes

### sonar-project.properties
- `sonar.projectVersion=1.0` → `0.1.0` (matches `pyproject.toml` and `__init__.py`)
- `sonar.python.version=3.11` → `3.10,3.11,3.12` (matches `requires-python>=3.10` and CI matrix)

### pyproject.toml
- **Removed** `requests>=2.31.0` from `dependencies` — confirmed never imported anywhere in the codebase. Dead dependency increases install time, supply chain surface, and triggers false CVE scanner alerts
- **Added** `[project.urls]` section with `Homepage`, `Documentation`, `Repository`, `Issues`, and `Changelog` links — PyPI project page previously showed no links

### CHANGELOG.md (new)
- 0.1.0 entry documenting all implemented guards (IamGuard, NetworkGuard, CostGuard), Terraform parser, 3-layer diagnostic model, numeric utilities, and CI/CD

## Verification
- `git grep -n "import requests\|from requests" -- "*.py"` — no results (dead dep confirmed)
- `git grep '__version__'` — matches `0.1.0` in both `__init__.py` and `pyproject.toml`
- 234/234 tests pass

## Related
- Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an initial `0.1.0` changelog entry describing newly released verification, reachability analysis, cost estimation, and infrastructure diagnostics capabilities, including fail-closed behavior.
  * Added project links for homepage, documentation, repository, issues, and changelog.

* **Chores**
  * Updated release tooling and quality settings to version `0.1.0`.
  * Expanded supported Python versions in project configuration.
  * Removed an unused runtime dependency from the package configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->