### PR TITLE
chore: v0.2.0 pre-release — version bump, README refresh, CHANGELOG, logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [0.2.0] - 2026-07-02
+
+### Added
+- ArtifactBoundaryGuard — deterministic release boundary verification (secret scanning, debug artifact detection, hatch build config validation)
+- audit.py + InfraDiagnosticResult — 3-layer diagnostic model ported from qwed-tax v0.2.0 (audit_trace, evidence, structured fields)
+- CONTRIBUTING.md, PR template, QWED_RULES.md, copilot-instructions — IaC-specific governance files
+- CI/CD — CodeQL, Snyk (IaC + SAST), SonarCloud security workflows
+- CHANGELOG.md — version tracking
+
+### Fixed
+- Terraform parser fail-closed — parse/normalization errors now produce BLOCKED, not silent continue (#8, #9)
+- IAM policy extraction — stripped policies now blocked instead of producing empty statements (#9)
+- CI fail-open — removed `|| true` and `continue-on-error` from verification steps (#10)
+- NetworkGuard internal traffic CIDR — false negative security gap (#14)
+- NetworkGuard unsupported topology — fail-closed on missing topology keys (#12)
+- CostGuard implicit defaults — unknown instance types now fail-closed instead of defaulting (#11)
+- CostGuard float→Decimal — exact financial arithmetic with ROUND_HALF_UP quantization (#15)
+- CostGuard unknown volume types — fail-closed on unhandled volume/storage types (#16)
+- IamGuard Z3 scope labeling — honest evaluation_in marking (Python vs Z3) (#17)
+- README examples — missing port arg, reason string mismatch, instance vs subnet id (#18)
+- Config sync — sonar version 1.0→0.1.0, python range fix, removed dead requests dependency (#20)
+
 ## [0.1.0] - 2026-07-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ print(result.reason) # -> "Estimated cost $47844.20 EXCEEDS budget $1000.00"
 from qwed_infra import ArtifactBoundaryGuard
 
 guard = ArtifactBoundaryGuard()
-result = guard.verify_package_boundary(package_dir=".")
+result = guard.verify_package_boundary(package_dir="qwed_infra")
 
 # Convert to structured diagnostic for CI/CD enforcement
 diagnostic = ArtifactBoundaryGuard.to_diagnostic(result)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <div align="center">
+  <img src="assets/logo.svg" alt="QWED Logo" width="80" height="80">
 
 # ☁️ QWED-Infra
 **Deterministic Verification for Infrastructure as Code (IaC)**
@@ -9,6 +10,13 @@
 [![PyPI](https://img.shields.io/pypi/v/qwed-infra?color=blue&logo=pypi&logoColor=white)](https://pypi.org/project/qwed-infra/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
+[![GitHub stars](https://img.shields.io/github/stars/QWED-AI/qwed-infra?style=social)](https://github.com/QWED-AI/qwed-infra)
+[![GitHub Developer Program](https://img.shields.io/badge/GitHub_Developer_Program-Member-4183C4?style=flat&logo=github&logoColor=white)](https://github.com/developer-program)
+
+<a href="https://github.com/sponsors/QWED-AI"><img src="https://img.shields.io/github/sponsors/QWED-AI?style=for-the-badge&logo=githubsponsors&label=Sponsor&color=EA4AAA" alt="Sponsor QWED on GitHub"></a>
+
+[![Twitter](https://img.shields.io/badge/Twitter-@rahuldass29-1DA1F2?style=flat&logo=twitter&logoColor=white)](https://x.com/rahuldass29)
+[![LinkedIn](https://img.shields.io/badge/LinkedIn-Rahul%20Dass-0077B5?style=flat&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/rahul-dass-23b370b0/)
 
 </div>
 
@@ -31,6 +39,7 @@ AI agents like **Devin**, **GitHub Copilot Workspace**, and **Cursor** are writi
 ### ✅ QWED-Infra IS:
 *   **A Deterministic Verification Engine:** Uses **Z3 Theorem Prover** to *prove* IAM action/resource matching, with IP and date conditions evaluated deterministically in Python.
 *   **A Graph Analyzer:** Uses **NetworkX** to map and verify network reachability (Reachability Analysis).
+*   **An Artifact Boundary Gate:** Scans release packages for secrets, debug artifacts, and misconfigured build paths — blocks unsafe releases before they ship.
 *   **Deterministic:** Inputs are code, output is `True/False` with 100% certainty.
 *   **A "Guard" Layer:** Plugs into CI/CD to block AI-generated PRs that violate rules.
 
@@ -53,7 +62,7 @@ AI agents like **Devin**, **GitHub Copilot Workspace**, and **Cursor** are writi
 
 ---
 
-## 🛡️ The Three Guards
+## 🛡️ The Four Guards
 
 ### 1. IamGuard (The Security Math)
 Converts AWS IAM Policies into logical formulas.
@@ -71,6 +80,13 @@ Builds a directed graph of your VPC.
 Prevents financial ruin.
 *   **Static Catalog:** Embedded prices for standard AWS resources.
 *   **Budget Checks:** `if estimated_cost > $500: Block Deployment`.
+
+### 4. ArtifactBoundaryGuard (The Release Gate)
+Verifies release artifacts before they ship.
+*   **Secret Scanning:** Detects leaked secrets (`.env`, `*.token`, API keys) in package files.
+*   **Debug Artifact Detection:** Blocks `.coverage`, `.pytest_cache`, `__pycache__` from entering packages.
+*   **Build Config Verification:** Ensures `pyproject.toml` hatch build config only includes intended paths.
+*   **Fail-Closed:** Unknown backends, missing configs, or unparseable files produce `BLOCKED`, never a silent pass.
 
 ---
 
@@ -153,6 +169,23 @@ print(result.within_budget) # -> False
 print(result.reason) # -> "Estimated cost $47844.20 EXCEEDS budget $1000.00"
 ```
 
+### Verify Package Boundary
+```python
+from qwed_infra import ArtifactBoundaryGuard
+
+guard = ArtifactBoundaryGuard()
+result = guard.verify_package_boundary(pkg_path=".")
+
+# Convert to structured diagnostic for CI/CD enforcement
+diagnostic = ArtifactBoundaryGuard.to_diagnostic(result)
+
+if diagnostic.status.value == "BLOCKED":
+    for finding in diagnostic.findings:
+        print(f"❌ {finding.rule_id}: {finding.message}")
+else:
+    print("✅ Package boundary verified — safe to ship.")
+```
+
 ---
 
 ## ❓ FAQ
@@ -170,30 +203,90 @@ A: We use public On-Demand pricing for "Worst Case" estimation. If you have Ente
 
 ## 🗺️ Roadmap
 
-*   ✅ **v0.1.0:** IAM Z3 Logic, Basic Network Graph, Static Cost Catalog. (Released)
-*   🚧 **v0.2.0:** K8s Manifest Verification, Azure Support.
-*   🔮 **v1.0.0:** VS Code Extension & GitHub App Auto-Commenter.
+*   ✅ **v0.1.0:** IAM Z3 Logic, Basic Network Graph, Static Cost Catalog. (Released Jan 2025)
+*   ✅ **v0.2.0:** Fail-closed parser + IAM, NetworkGuard CIDR fix, CI fail-open removal, diagnostic port (audit.py/InfraDiagnosticResult), CostGuard Decimal/unknown types, ArtifactBoundaryGuard. (Current)
+*   🔮 **v0.3.0:** Docker/deployment artifact verification, K8s manifest support, Azure provider.
 
 ---
 
 ## 🌐 QWED Ecosystem
 
-| Package | What it does |
-|---------|-------------|
-| **[qwed-verification](https://github.com/QWED-AI/qwed-verification)** | Core deterministic AI verification (Math, Logic, Code) |
-| **[qwed-open-responses](https://github.com/QWED-AI/qwed-open-responses)** | Guards for OpenAI/LangChain agent outputs |
-| **[qwed-infra](https://github.com/QWED-AI/qwed-infra)** ← you are here | IaC verification (Terraform/IAM/Network/Cost) |
-| **[qwed-a2a](https://github.com/QWED-AI/qwed-a2a)** | Agent-to-Agent verification protocol |
-| **[qwed-mcp](https://github.com/QWED-AI/qwed-mcp)** | Model Context Protocol verification |
-| **[qwed-ucp](https://github.com/QWED-AI/qwed-ucp)** | Unified Context Protocol |
-| **[qwed-finance](https://github.com/QWED-AI/qwed-finance)** | Financial computation verification |
-| **[qwed-tax](https://github.com/QWED-AI/qwed-tax)** | Tax calculation verification |
-| **[qwed-legal](https://github.com/QWED-AI/qwed-legal)** | Legal document verification |
-| **[qwed-learning](https://github.com/QWED-AI/qwed-learning)** | Educational content verification |
+| Package | Description | Repo |
+|---------|-------------|------|
+| **qwed** ☑️ | Core deterministic AI verification (Math, Logic, Code) | [GitHub](https://github.com/QWED-AI/qwed-verification) |
+| **qwed-infra** ☁️ | IaC verification (Terraform, IAM, Network, Cost, Artifact) ← **you are here** | [GitHub](https://github.com/QWED-AI/qwed-infra) |
+| **qwed-finance** 🏦 | Financial computation verification | [GitHub](https://github.com/QWED-AI/qwed-finance) |
+| **qwed-legal** 🏛️ | Legal document verification | [GitHub](https://github.com/QWED-AI/qwed-legal) |
+| **qwed-tax** 💸 | Tax calculation verification | [GitHub](https://github.com/QWED-AI/qwed-tax) |
+| **qwed-mcp** 🔌 | Model Context Protocol verification | [GitHub](https://github.com/QWED-AI/qwed-mcp) |
+| **qwed-a2a** 🔄 | Agent-to-Agent verification protocol | [GitHub](https://github.com/QWED-AI/qwed-a2a) |
+| **qwed-ucp** 🛒 | Unified Context Protocol | [GitHub](https://github.com/QWED-AI/qwed-ucp) |
+| **open-responses** 🤖 | Guards for OpenAI/LangChain agent outputs | [GitHub](https://github.com/QWED-AI/qwed-open-responses) |
+| **qwed-learning** 📚 | Educational content verification | [GitHub](https://github.com/QWED-AI/qwed-learning) |
+
+---
+
+## 🛡️ What Does "Verified by QWED" Mean?
+
+When you see the **Verified by QWED** badge on a repository, it is a technical guarantee that:
+
+1. **Deterministic Verification:** The software uses symbolic solvers (Z3, graph theory) — not AI confidence scores — to prove correctness.
+2. **Fail-Closed Architecture:** If the infrastructure cannot be fully parsed or verified, it is **blocked**, not silently passed.
+3. **No Silent Degradation:** Every guard produces a structured diagnostic with clear status (`VERIFIED`, `BLOCKED`, `UNVERIFIABLE`). Partial verification is never presented as proof.
+
+> **The badge means: "We don't trust the AI. We trust the Math."**
+
+---
+
+## ⭐ Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=QWED-AI/qwed-infra&type=Date)](https://star-history.com/#QWED-AI/qwed-infra&Date)
+
+---
+
+## 📄 Citation
+
+If you use qwed-infra in your research or project:
+
+```bibtex
+@software{dass2025qwedinfra,
+  author = {Dass, Rahul},
+  title = {QWED-Infra: Deterministic Verification for Infrastructure as Code},
+  year = {2025},
+  publisher = {GitHub},
+  url = {https://github.com/QWED-AI/qwed-infra}
+}
+```
+
+---
+
+## 👥 Contributors
+
+<a href="https://github.com/rahuldass19">
+  <img src="https://github.com/rahuldass19.png?size=96" width="48px;" alt="Rahul Dass" />
+</a>
+
+Thanks to everyone building QWED. [See all contributors →](https://github.com/QWED-AI/qwed-infra/graphs/contributors)
+
+---
+
+## 🙏 Contributors Wanted
+
+[![Good First Issues](https://img.shields.io/github/issues/QWED-AI/qwed-infra/good%20first%20issue?label=good%20first%20issues&color=7057ff)](https://github.com/QWED-AI/qwed-infra/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+
+| Area | What We Need |
+|------|-------------|
+| 🧪 **Testing** | Edge cases for guards (NetworkGuard, ArtifactBoundaryGuard) |
+| 🐛 **Bugs** | Fix issues or report new ones |
+| 📝 **Docs** | Improve examples and tutorials |
+| 🔧 **SDKs** | Terraform plan JSON integration |
+
+**[→ Read CONTRIBUTING.md](CONTRIBUTING.md)**
 
 ---
 
 ## 📄 License
+
 Apache 2.0 - Open Source.
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -174,14 +174,14 @@ print(result.reason) # -> "Estimated cost $47844.20 EXCEEDS budget $1000.00"
 from qwed_infra import ArtifactBoundaryGuard
 
 guard = ArtifactBoundaryGuard()
-result = guard.verify_package_boundary(pkg_path=".")
+result = guard.verify_package_boundary(package_dir=".")
 
 # Convert to structured diagnostic for CI/CD enforcement
 diagnostic = ArtifactBoundaryGuard.to_diagnostic(result)
 
 if diagnostic.status.value == "BLOCKED":
-    for finding in diagnostic.findings:
-        print(f"❌ {finding.rule_id}: {finding.message}")
+    for finding in diagnostic.developer_fields["findings"]:
+        print(f"❌ {finding['finding_type']}: {finding['reason']}")
 else:
     print("✅ Package boundary verified — safe to ship.")
 ```
@@ -249,10 +249,10 @@ When you see the **Verified by QWED** badge on a repository, it is a technical g
 If you use qwed-infra in your research or project:
 
 ```bibtex
-@software{dass2025qwedinfra,
+@software{dass2026qwedinfra,
   author = {Dass, Rahul},
   title = {QWED-Infra: Deterministic Verification for Infrastructure as Code},
-  year = {2025},
+  year = {2026},
   publisher = {GitHub},
   url = {https://github.com/QWED-AI/qwed-infra}
 }

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <!-- Shield background -->
+  <path d="M50 5 L90 20 L90 50 C90 75 50 95 50 95 C50 95 10 75 10 50 L10 20 Z" 
+        fill="#10b981" opacity="0.2"/>
+  
+  <!-- Shield outline -->
+  <path d="M50 5 L90 20 L90 50 C90 75 50 95 50 95 C50 95 10 75 10 50 L10 20 Z" 
+        fill="none" stroke="#10b981" stroke-width="3"/>
+  
+  <!-- Check mark (verification) -->
+  <path d="M30 50 L45 65 L70 35" 
+        fill="none" stroke="#10b981" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  
+  <!-- Q letter hint (subtle) -->
+  <circle cx="50" cy="48" r="15" fill="none" stroke="#10b981" stroke-width="2" opacity="0.3"/>
+  <path d="M58 56 L68 66" stroke="#10b981" stroke-width="2" stroke-linecap="round" opacity="0.3"/>
+</svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwed-infra"
-version = "0.1.0"
+version = "0.2.0"
 description = "Deterministic Verification for Infrastructure as Code (IaC) using Z3 and Graph Theory."
 authors = [
     {name = "QWED Team", email = "rahul@qwedai.com"},

--- a/qwed_infra/__init__.py
+++ b/qwed_infra/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 from .guards.iam_guard import IamGuard
 from .guards.network_guard import NetworkGuard

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=QWED-AI_qwed-infra
 sonar.organization=qwed-ai
 
 sonar.projectName=QWED Infra
-sonar.projectVersion=0.1.0
+sonar.projectVersion=0.2.0
 
 # Source directories
 sonar.sources=qwed_infra


### PR DESCRIPTION
## Summary

Bumps qwed-infra to **v0.2.0** for the first release since Jan 2025. All P0/P1/P2 issues from tracker #7 are resolved. README is restructured to reflect the new 4-guard architecture and aligned with the qwed-verification core README style.

## Changes

### Version bump (5 files)
- `pyproject.toml`: 0.1.0 → 0.2.0
- `qwed_infra/__init__.py`: 0.1.0 → 0.2.0
- `sonar-project.properties`: 0.1.0 → 0.2.0
- `CHANGELOG.md`: Full v0.2.0 entry with all fixes and features since last release
- `README.md`: Roadmap now reflects actual v0.2.0 content

### README restructure
- **Logo**: Added QWED shield logo at top
- **Badges**: Added GitHub stars, GitHub Developer Program, Sponsor button, social links
- **"What QWED-Infra IS"**: Added "Artifact Boundary Gate" to description
- **"3 Guards" → "4 Guards"**: Added ArtifactBoundaryGuard
- **Usage examples**: Added `Verify Package Boundary` example
- **Roadmap**: Updated v0.2.0 to show shipped items (diagnostic port, fail-closed hardening, ArtifactBoundaryGuard)
- **New sections**: Verified by QWED explanation, Star History, Citation, Contributors, Contributors Wanted

### Changelog
Comprehensive v0.2.0 entry documenting all fixes and features since Jan 2025.

## Key PRs included

| Issue | PR | Description |
|-------|----|-------------|
| #8, #9 | #21 | Parser fail-closed + IAM extraction |
| #14 | #22 | NetworkGuard CIDR false negative |
| #10 | #24 | CI fail-open removal |
| #17 | #26/#27 | IamGuard Z3 scope labeling |
| #12 | #28 | NetworkGuard unsupported topology |
| #16 | #29 | CostGuard unknown volume types |
| #11 | #30 | CostGuard implicit defaults |
| #15 | #31 | CostGuard float→Decimal |
| #18 | #32 | README examples fix |
| #20 | #33 | Config sync |
| #6 | #34 | ArtifactBoundaryGuard |

## Status

✅ Ready for review. After merge, tag as `v0.2.0` on PyPI.