### PR TITLE
feat: add verification_context_bridge module (#37)

### DIFF
--- a/qwed_infra/__init__.py
+++ b/qwed_infra/__init__.py
@@ -5,3 +5,19 @@ from .guards.network_guard import NetworkGuard
 from .guards.cost_guard import CostGuard
 from .guards.artifact_boundary_guard import ArtifactBoundaryGuard
 from .parsers.terraform_parser import TerraformParser
+from .verification_context import (
+    Admission,
+    Decision,
+    Evidence,
+    Formalization,
+    Interpretation,
+    Proof,
+    Verdict,
+    VerificationContext,
+    VerificationContextDocument,
+    VerificationContextValidationError,
+    compute_document_proof_ref,
+    resolve_document_proof_ref,
+    is_valid_document,
+)
+from .verification_context_bridge import verification_context_from_diagnostic_result

--- a/qwed_infra/verification_context.py
+++ b/qwed_infra/verification_context.py
@@ -479,10 +479,41 @@ def _has_valid_context(document: Mapping[str, Any]) -> bool:
     return True
 
 
+def _is_safe_string(value: Any) -> bool:
+    """Check value is a non-empty, surrogate-free canonical string."""
+    if not isinstance(value, str) or not value.strip():
+        return False
+    try:
+        _reject_unpaired_surrogates(value)
+        return True
+    except VerificationContextValidationError:
+        return False
+
+
 def _has_valid_interpretation(interp: Mapping[str, Any]) -> bool:
     for field in ("theory", "logic"):
-        val = interp.get(field)
-        if not isinstance(val, str) or not val.strip():
+        if not _is_safe_string(interp.get(field)):
+            return False
+    return True
+
+
+def _is_serializable_string(value: str) -> bool:
+    try:
+        _reject_unpaired_surrogates(value)
+        return True
+    except VerificationContextValidationError:
+        return False
+
+
+def _is_serializable_sequence(value) -> bool:
+    return all(_is_serializable(item) for item in value)
+
+
+def _is_serializable_mapping(value: Mapping) -> bool:
+    for key, item in value.items():
+        if not isinstance(key, str) or not _is_serializable_string(key):
+            return False
+        if not _is_serializable(item):
             return False
     return True
 
@@ -496,31 +527,17 @@ def _is_serializable(value: Any) -> bool:
     if isinstance(value, float):
         return math.isfinite(value)
     if isinstance(value, str):
-        try:
-            _reject_unpaired_surrogates(value)
-            return True
-        except VerificationContextValidationError:
-            return False
+        return _is_serializable_string(value)
     if isinstance(value, (list, tuple)):
-        return all(_is_serializable(item) for item in value)
+        return _is_serializable_sequence(value)
     if isinstance(value, Mapping):
-        for key, item in value.items():
-            if not isinstance(key, str):
-                return False
-            try:
-                _reject_unpaired_surrogates(key)
-            except VerificationContextValidationError:
-                return False
-            if not _is_serializable(item):
-                return False
-        return True
+        return _is_serializable_mapping(value)
     return False
 
 
 def _has_valid_proof(proof: Mapping[str, Any]) -> bool:
     for field in ("verifier", "verifier_version", "theory_scope", "outcome_treatment"):
-        val = proof.get(field)
-        if not isinstance(val, str) or not val.strip():
+        if not _is_safe_string(proof.get(field)):
             return False
     config = proof.get("configuration")
     if not isinstance(config, Mapping) or not _is_serializable(config):
@@ -529,7 +546,7 @@ def _has_valid_proof(proof: Mapping[str, Any]) -> bool:
     if not isinstance(deps, list):
         return False
     for dep in deps:
-        if not isinstance(dep, str) or not dep.strip():
+        if not _is_safe_string(dep):
             return False
     return True
 

--- a/qwed_infra/verification_context.py
+++ b/qwed_infra/verification_context.py
@@ -1,0 +1,410 @@
+"""
+QWED-Infra Verification Context v1.0 Model Types.
+
+Independent implementation of the Verification Context contract,
+following the same pattern as InfraDiagnosticResult (no dependency
+on qwed-verification, mirrors the VC contract exactly).
+
+See: qwed-verification/spec/v1.0/verification-context.md
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import math
+import re
+from dataclasses import dataclass, replace
+from enum import Enum
+from functools import lru_cache
+from types import MappingProxyType
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+SPEC_VERSION = "1.0"
+_PROOF_REF_PATTERN = re.compile(r"sha256:[a-f0-9]{64}")
+
+
+class VerificationContextValidationError(ValueError):
+    pass
+
+
+class Verdict(str, Enum):
+    VERIFIED = "VERIFIED"
+    UNVERIFIABLE = "UNVERIFIABLE"
+    BLOCKED = "BLOCKED"
+
+
+class Admission(str, Enum):
+    ADMIT = "ADMIT"
+    DENY = "DENY"
+
+
+def _freeze_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType(
+            {key: _freeze_value(item) for key, item in value.items()}
+        )
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_value(item) for item in value)
+    return value
+
+
+def _thaw_value(value: Any) -> Any:
+    if isinstance(value, MappingProxyType):
+        return {key: _thaw_value(item) for key, item in value.items()}
+    if isinstance(value, Mapping):
+        return {key: _thaw_value(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_value(item) for item in value]
+    return value
+
+
+@dataclass(frozen=True)
+class Formalization:
+    source_query: str
+    translator: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.source_query, str) or not self.source_query.strip():
+            raise VerificationContextValidationError(
+                "Formalization.source_query must be a non-empty string"
+            )
+        if not isinstance(self.translator, str) or not self.translator.strip():
+            raise VerificationContextValidationError(
+                "Formalization.translator must be a non-empty string"
+            )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "source_query": self.source_query,
+            "translator": self.translator,
+        }
+
+
+@dataclass(frozen=True)
+class Interpretation:
+    theory: str
+    logic: str = "deterministic pattern matching"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.theory, str) or not self.theory.strip():
+            raise VerificationContextValidationError(
+                "Interpretation.theory must be a non-empty string"
+            )
+        if not isinstance(self.logic, str) or not self.logic.strip():
+            raise VerificationContextValidationError(
+                "Interpretation.logic must be a non-empty string"
+            )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "theory": self.theory,
+            "logic": self.logic,
+        }
+
+
+@dataclass(frozen=True)
+class Proof:
+    verifier: str
+    verifier_version: str
+    configuration: Dict[str, Any]
+    theory_scope: str
+    trusted_dependencies: Tuple[str, ...]
+    outcome_treatment: str
+
+    def __post_init__(self) -> None:
+        for field_name in ("verifier", "verifier_version", "theory_scope", "outcome_treatment"):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value.strip():
+                raise VerificationContextValidationError(
+                    f"Proof.{field_name} must be a non-empty string"
+                )
+        if not isinstance(self.configuration, dict):
+            raise VerificationContextValidationError(
+                "Proof.configuration must be a dict"
+            )
+        if not isinstance(self.trusted_dependencies, tuple):
+            raise VerificationContextValidationError(
+                "Proof.trusted_dependencies must be a tuple of strings"
+            )
+        for dep in self.trusted_dependencies:
+            if not isinstance(dep, str):
+                raise VerificationContextValidationError(
+                    "Proof.trusted_dependencies must contain only strings"
+                )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "verifier": self.verifier,
+            "verifier_version": self.verifier_version,
+            "configuration": self.configuration,
+            "theory_scope": self.theory_scope,
+            "trusted_dependencies": list(self.trusted_dependencies),
+            "outcome_treatment": self.outcome_treatment,
+        }
+
+
+@dataclass(frozen=True)
+class Evidence:
+    payload: Dict[str, Any]
+    proof_ref: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.payload, dict):
+            raise VerificationContextValidationError(
+                "Evidence.payload must be a dict"
+            )
+        if self.proof_ref is not None:
+            if not isinstance(self.proof_ref, str) or not _PROOF_REF_PATTERN.fullmatch(self.proof_ref):
+                raise VerificationContextValidationError(
+                    "Evidence.proof_ref must match sha256:<64-hex> or be None"
+                )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "payload": self.payload,
+            "proof_ref": self.proof_ref,
+        }
+
+
+@dataclass(frozen=True)
+class Decision:
+    admission: Admission
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.admission, Admission):
+            raise VerificationContextValidationError(
+                "Decision.admission must be an Admission enum value"
+            )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"admission": self.admission.value}
+
+
+@dataclass(frozen=True)
+class VerificationContext:
+    interpretation: Interpretation
+    proof: Proof
+    evidence: Evidence
+    decision: Decision
+
+    def __post_init__(self) -> None:
+        for field_name, expected_type in (
+            ("interpretation", Interpretation),
+            ("proof", Proof),
+            ("evidence", Evidence),
+            ("decision", Decision),
+        ):
+            value = getattr(self, field_name)
+            if not isinstance(value, expected_type):
+                raise VerificationContextValidationError(
+                    f"VerificationContext.{field_name} must be a {expected_type.__name__}"
+                )
+        if self.evidence.proof_ref is not None and self.decision.admission is Admission.DENY:
+            raise VerificationContextValidationError(
+                "DENY admission requires proof_ref is None — "
+                "fail-closed contract: UNVERIFIABLE/BLOCKED never admit"
+            )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "interpretation": self.interpretation.to_dict(),
+            "proof": self.proof.to_dict(),
+            "evidence": self.evidence.to_dict(),
+            "decision": self.decision.to_dict(),
+        }
+
+
+def _canonical_json(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        try:
+            as_float = float(value)
+        except OverflowError as exc:
+            raise VerificationContextValidationError(
+                f"integer not representable as IEEE-754 double: {value!r}"
+            ) from exc
+        if int(as_float) != value:
+            raise VerificationContextValidationError(
+                f"integer not representable as IEEE-754 double: {value!r}"
+            )
+        return _es_number_to_string(as_float)
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise VerificationContextValidationError(
+                f"non-finite number not allowed in proof_ref payload: {value!r}"
+            )
+        return _es_number_to_string(value)
+    if isinstance(value, str):
+        _reject_unpaired_surrogates(value)
+        return json.dumps(value, ensure_ascii=False)
+    if isinstance(value, (list, tuple)):
+        return "[" + ",".join(_canonical_json(item) for item in value) + "]"
+    if isinstance(value, Mapping):
+        for key in value:
+            if not isinstance(key, str):
+                raise VerificationContextValidationError(
+                    f"non-string object key not allowed in proof_ref payload: {key!r}"
+                )
+            _reject_unpaired_surrogates(key)
+        items = sorted(value.items(), key=lambda kv: kv[0].encode("utf-16-be"))
+        return (
+            "{"
+            + ",".join(
+                json.dumps(k, ensure_ascii=False) + ":" + _canonical_json(v)
+                for k, v in items
+            )
+            + "}"
+        )
+    raise VerificationContextValidationError(
+        f"unsupported type in proof_ref payload: {type(value).__name__}"
+    )
+
+
+def _es_number_to_string(value: float) -> str:
+    neg = value < 0
+    coeff, e10 = _parse_es_decimal(value)
+    out = _format_es_decimal(coeff, e10)
+    if neg and out != "0":
+        return "-" + out
+    return out
+
+
+def _parse_es_decimal(value: float) -> Tuple[int, int]:
+    if not math.isfinite(value):
+        raise VerificationContextValidationError(
+            f"non-finite number not allowed: {value!r}"
+        )
+    import decimal
+    d = decimal.Decimal(repr(value))
+    sign, digits, exponent = d.as_tuple()
+    coeff = int("".join(str(i) for i in digits))
+    return coeff, exponent
+
+
+def _format_es_decimal(coeff: int, exponent: int) -> str:
+    if coeff == 0:
+        return "0"
+    s = str(coeff)
+    if exponent >= 0:
+        return s + "0" * exponent
+    if len(s) > abs(exponent):
+        point = len(s) + exponent
+        return s[:point] + "." + s[point:]
+    return "0." + "0" * abs(exponent + len(s)) + s
+
+
+def _reject_unpaired_surrogates(value: str) -> None:
+    for i, ch in enumerate(value):
+        cp = ord(ch)
+        if 0xD800 <= cp <= 0xDBFF:  # high surrogate
+            if i + 1 >= len(value) or not (0xDC00 <= ord(value[i + 1]) <= 0xDFFF):
+                raise VerificationContextValidationError(
+                    f"unpaired high surrogate at position {i}: {value!r}"
+                )
+        elif 0xDC00 <= cp <= 0xDFFF:  # low surrogate
+            if i == 0 or not (0xD800 <= ord(value[i - 1]) <= 0xDBFF):
+                raise VerificationContextValidationError(
+                    f"unpaired low surrogate at position {i}: {value!r}"
+                )
+
+
+def compute_document_proof_ref(document: Mapping[str, Any]) -> str:
+    formal_statement = document["object"]["formal_statement"]
+    context_dict = document["context"]
+    evidence_dict = {
+        key: value
+        for key, value in context_dict["evidence"].items()
+        if key != "proof_ref"
+    }
+    bound = {
+        "formal_statement": formal_statement,
+        "context": {**context_dict, "evidence": evidence_dict},
+    }
+    payload = _canonical_json(bound)
+    return "sha256:" + hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def resolve_document_proof_ref(document: Mapping[str, Any]) -> bool:
+    try:
+        if not isinstance(document, Mapping):
+            return False
+        if document.get("verdict") != Verdict.VERIFIED.value:
+            return False
+        expected = compute_document_proof_ref(document)
+        stored = document["context"]["evidence"]["proof_ref"]
+        return isinstance(stored, str) and stored == expected
+    except (VerificationContextValidationError, KeyError, TypeError, AttributeError):
+        return False
+
+
+def is_valid_document(document: Mapping[str, Any]) -> bool:
+    try:
+        if not isinstance(document, Mapping):
+            return False
+        if document.get("spec_version") != SPEC_VERSION:
+            return False
+        if document.get("verdict") not in {"VERIFIED", "UNVERIFIABLE", "BLOCKED"}:
+            return False
+        return True
+    except (KeyError, TypeError, AttributeError):
+        return False
+
+
+@dataclass(frozen=True)
+class VerificationContextDocument:
+    spec_version: str
+    object: Dict[str, Any]
+    context: VerificationContext
+    verdict: Verdict
+    formalization: Optional[Formalization] = None
+
+    def __post_init__(self) -> None:
+        if self.spec_version != SPEC_VERSION:
+            raise VerificationContextValidationError(
+                f"spec_version must be {SPEC_VERSION}"
+            )
+        if not isinstance(self.object, dict):
+            raise VerificationContextValidationError(
+                "object must be a dict with formal_statement"
+            )
+        formal_statement = self.object.get("formal_statement")
+        if not isinstance(formal_statement, str) or not formal_statement.strip():
+            raise VerificationContextValidationError(
+                "object.formal_statement must be a non-empty string"
+            )
+        if not isinstance(self.verdict, Verdict):
+            raise VerificationContextValidationError(
+                "verdict must be VERIFIED, UNVERIFIABLE, or BLOCKED"
+            )
+        if self.verdict is Verdict.VERIFIED and self.context.evidence.proof_ref is None:
+            raise VerificationContextValidationError(
+                "VERIFIED verdict requires context.evidence.proof_ref to be non-null"
+            )
+        if self.verdict is not Verdict.VERIFIED and self.context.evidence.proof_ref is not None:
+            raise VerificationContextValidationError(
+                f"{self.verdict.value} verdict requires proof_ref to be null"
+            )
+        if self.verdict is Verdict.VERIFIED and self.context.decision.admission is Admission.DENY:
+            raise VerificationContextValidationError(
+                "VERIFIED verdict requires ADMIT admission"
+            )
+        if self.verdict is not Verdict.VERIFIED and self.context.decision.admission is Admission.ADMIT:
+            raise VerificationContextValidationError(
+                f"{self.verdict.value} verdict requires DENY admission"
+            )
+
+    def to_dict(self) -> Dict[str, Any]:
+        doc = {
+            "spec_version": self.spec_version,
+            "object": self.object,
+            "context": self.context.to_dict(),
+            "verdict": self.verdict.value,
+        }
+        if self.formalization is not None:
+            doc["object"]["formalization"] = self.formalization.to_dict()
+        return doc

--- a/qwed_infra/verification_context.py
+++ b/qwed_infra/verification_context.py
@@ -505,7 +505,13 @@ def _is_serializable(value: Any) -> bool:
         return all(_is_serializable(item) for item in value)
     if isinstance(value, Mapping):
         for key, item in value.items():
-            if not isinstance(key, str) or not _is_serializable(item):
+            if not isinstance(key, str):
+                return False
+            try:
+                _reject_unpaired_surrogates(key)
+            except VerificationContextValidationError:
+                return False
+            if not _is_serializable(item):
                 return False
         return True
     return False

--- a/qwed_infra/verification_context.py
+++ b/qwed_infra/verification_context.py
@@ -488,7 +488,7 @@ def _has_valid_proof(proof: Mapping[str, Any]) -> bool:
     if not isinstance(deps, list):
         return False
     for dep in deps:
-        if not isinstance(dep, str):
+        if not isinstance(dep, str) or not dep.strip():
             return False
     return True
 

--- a/qwed_infra/verification_context.py
+++ b/qwed_infra/verification_context.py
@@ -561,6 +561,10 @@ def _has_valid_evidence(evidence: Mapping[str, Any]) -> bool:
     payload = evidence.get("payload")
     if not isinstance(payload, dict) or not _is_serializable(payload):
         return False
+    # proof_ref key must be present (explicitly null for non-VERIFIED);
+    # an absent member is not the same as an explicit null.
+    if "proof_ref" not in evidence:
+        return False
     return True
 
 
@@ -581,6 +585,10 @@ class VerificationContextDocument:
     formalization: Optional[Formalization] = None
 
     def __post_init__(self) -> None:
+        if self.formalization is not None and not isinstance(self.formalization, Formalization):
+            raise VerificationContextValidationError(
+                "formalization must be a Formalization instance or None"
+            )
         if not isinstance(self.object, dict):
             raise VerificationContextValidationError(
                 "object must be a dict with formal_statement"

--- a/qwed_infra/verification_context.py
+++ b/qwed_infra/verification_context.py
@@ -70,10 +70,12 @@ class Formalization:
             raise VerificationContextValidationError(
                 "Formalization.source_query must be a non-empty string"
             )
+        _reject_unpaired_surrogates(self.source_query)
         if not isinstance(self.translator, str) or not self.translator.strip():
             raise VerificationContextValidationError(
                 "Formalization.translator must be a non-empty string"
             )
+        _reject_unpaired_surrogates(self.translator)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -92,10 +94,12 @@ class Interpretation:
             raise VerificationContextValidationError(
                 "Interpretation.theory must be a non-empty string"
             )
+        _reject_unpaired_surrogates(self.theory)
         if not isinstance(self.logic, str) or not self.logic.strip():
             raise VerificationContextValidationError(
                 "Interpretation.logic must be a non-empty string"
             )
+        _reject_unpaired_surrogates(self.logic)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -124,6 +128,7 @@ class Proof:
                 raise VerificationContextValidationError(
                     f"Proof.{field_name} must be a non-empty string"
                 )
+            _reject_unpaired_surrogates(value)
         if not isinstance(self.configuration, dict):
             raise VerificationContextValidationError(
                 "Proof.configuration must be a dict"
@@ -142,6 +147,7 @@ class Proof:
                 raise VerificationContextValidationError(
                     "Proof.trusted_dependencies must contain only non-empty strings"
                 )
+            _reject_unpaired_surrogates(dep)
 
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/qwed_infra/verification_context.py
+++ b/qwed_infra/verification_context.py
@@ -128,6 +128,10 @@ class Proof:
             raise VerificationContextValidationError(
                 "Proof.configuration must be a dict"
             )
+        if not _is_serializable(self.configuration):
+            raise VerificationContextValidationError(
+                "Proof.configuration contains unsupported non-canonical values"
+            )
         object.__setattr__(self, 'configuration', _freeze_value(copy.deepcopy(self.configuration)))
         if not isinstance(self.trusted_dependencies, tuple):
             raise VerificationContextValidationError(
@@ -159,6 +163,10 @@ class Evidence:
         if not isinstance(self.payload, dict):
             raise VerificationContextValidationError(
                 "Evidence.payload must be a dict"
+            )
+        if not _is_serializable(self.payload):
+            raise VerificationContextValidationError(
+                "Evidence.payload contains unsupported non-canonical values"
             )
         object.__setattr__(self, 'payload', _freeze_value(copy.deepcopy(self.payload)))
         if self.proof_ref is not None:
@@ -440,6 +448,8 @@ def _has_valid_object(document: Mapping[str, Any]) -> bool:
     obj = document.get("object")
     if not isinstance(obj, Mapping):
         return False
+    if not _is_serializable(obj):
+        return False
     if not isinstance(obj.get("formal_statement"), str) or not obj.get("formal_statement", "").strip():
         return False
     formalization = obj.get("formalization")
@@ -545,6 +555,10 @@ class VerificationContextDocument:
         if not isinstance(self.object, dict):
             raise VerificationContextValidationError(
                 "object must be a dict with formal_statement"
+            )
+        if not _is_serializable(self.object):
+            raise VerificationContextValidationError(
+                "object contains unsupported non-canonical values"
             )
         object.__setattr__(self, 'object', _freeze_value(copy.deepcopy(self.object)))
         if self.spec_version != SPEC_VERSION:

--- a/qwed_infra/verification_context.py
+++ b/qwed_infra/verification_context.py
@@ -11,6 +11,7 @@ See: qwed-verification/spec/v1.0/verification-context.md
 from __future__ import annotations
 
 import copy
+import decimal
 import hashlib
 import json
 import math
@@ -141,7 +142,7 @@ class Proof:
         return {
             "verifier": self.verifier,
             "verifier_version": self.verifier_version,
-            "configuration": self.configuration,
+            "configuration": copy.deepcopy(self.configuration),
             "theory_scope": self.theory_scope,
             "trusted_dependencies": list(self.trusted_dependencies),
             "outcome_treatment": self.outcome_treatment,
@@ -154,6 +155,9 @@ class Evidence:
     proof_ref: Optional[str] = None
 
     def __post_init__(self) -> None:
+        # Deep-copy the payload to prevent post-construction caller mutation from
+        # affecting the proof-bound document (aliases break proof_ref resolution).
+        object.__setattr__(self, 'payload', copy.deepcopy(self.payload))
         if not isinstance(self.payload, dict):
             raise VerificationContextValidationError(
                 "Evidence.payload must be a dict"
@@ -166,7 +170,7 @@ class Evidence:
 
     def to_dict(self) -> Dict[str, Any]:
         return {
-            "payload": self.payload,
+            "payload": copy.deepcopy(self.payload),
             "proof_ref": self.proof_ref,
         }
 
@@ -229,57 +233,101 @@ def _canonical_json(value: Any) -> str:
         return "null"
     if isinstance(value, bool):
         return "true" if value else "false"
-    if isinstance(value, int):
-        try:
-            as_float = float(value)
-        except OverflowError as exc:
-            raise VerificationContextValidationError(
-                f"integer not representable as IEEE-754 double: {value!r}"
-            ) from exc
-        if int(as_float) != value:
-            raise VerificationContextValidationError(
-                f"integer not representable as IEEE-754 double: {value!r}"
-            )
-        return _es_number_to_string(as_float)
-    if isinstance(value, float):
-        if not math.isfinite(value):
-            raise VerificationContextValidationError(
-                f"non-finite number not allowed in proof_ref payload: {value!r}"
-            )
-        return _es_number_to_string(value)
+    if isinstance(value, (int, float)):
+        return _canonical_json_number(value)
     if isinstance(value, str):
         _reject_unpaired_surrogates(value)
         return json.dumps(value, ensure_ascii=False)
     if isinstance(value, (list, tuple)):
         return "[" + ",".join(_canonical_json(item) for item in value) + "]"
     if isinstance(value, Mapping):
-        for key in value:
-            if not isinstance(key, str):
-                raise VerificationContextValidationError(
-                    f"non-string object key not allowed in proof_ref payload: {key!r}"
-                )
-            _reject_unpaired_surrogates(key)
-        items = sorted(value.items(), key=lambda kv: kv[0].encode("utf-16-be"))
-        return (
-            "{"
-            + ",".join(
-                json.dumps(k, ensure_ascii=False) + ":" + _canonical_json(v)
-                for k, v in items
-            )
-            + "}"
-        )
+        return _canonical_json_mapping(value)
     raise VerificationContextValidationError(
         f"unsupported type in proof_ref payload: {type(value).__name__}"
     )
 
 
+def _canonical_json(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return _canonical_json_number(value)
+    if isinstance(value, str):
+        _reject_unpaired_surrogates(value)
+        return json.dumps(value, ensure_ascii=False)
+    if isinstance(value, (list, tuple)):
+        return "[" + ",".join(_canonical_json(item) for item in value) + "]"
+    if isinstance(value, Mapping):
+        return _canonical_json_mapping(value)
+    raise VerificationContextValidationError(
+        f"unsupported type in proof_ref payload: {type(value).__name__}"
+    )
+
+
+def _canonical_json_number(value) -> str:
+    """Serialize int/float to canonical JSON with IEEE-754 float semantics."""
+    if isinstance(value, int):
+        if not _is_safe_integer(value):
+            raise VerificationContextValidationError(
+                f"integer not representable as IEEE-754 double: {value!r}"
+            )
+        return str(value)
+    if not math.isfinite(value):
+        raise VerificationContextValidationError(
+            f"non-finite number not allowed in proof_ref payload: {value!r}"
+        )
+    if not isinstance(value, bool) and isinstance(value, float):
+        return _es_number_to_string(value)
+    raise VerificationContextValidationError(
+        f"unsupported numeric type in proof_ref payload: {type(value).__name__}"
+    )
+
+
+def _is_safe_integer(value: int) -> bool:
+    """Check if int is safely representable as IEEE-754 double."""
+    return -(2**53 - 1) <= value <= 2**53 - 1
+
+
+def _canonical_json_mapping(value) -> str:
+    """Serialize Mapping to canonical JSON with sorted keys (UTF-16-BE order)."""
+    for key in value:
+        if not isinstance(key, str):
+            raise VerificationContextValidationError(
+                f"non-string object key not allowed in proof_ref payload: {key!r}"
+            )
+        _reject_unpaired_surrogates(key)
+    items = sorted(value.items(), key=lambda kv: kv[0].encode("utf-16-be"))
+    return (
+        "{"
+        + ",".join(
+            json.dumps(k, ensure_ascii=False) + ":" + _canonical_json(v)
+            for k, v in items
+        )
+        + "}"
+    )
+
+
 def _es_number_to_string(value: float) -> str:
-    neg = value < 0
-    coeff, e10 = _parse_es_decimal(value)
-    out = _format_es_decimal(coeff, e10)
-    if neg and out != "0":
-        return "-" + out
-    return out
+    """Serialize float to ECMAScript Number::toString (RFC 8785/JCS compatible)."""
+    if not math.isfinite(value):
+        raise VerificationContextValidationError(
+            f"non-finite number not allowed in proof_ref payload: {value!r}"
+        )
+    if value == 0:
+        return "0"
+    r = repr(value)
+    # Integer-valued floats within ECMAScript safe integer range: strip trailing .0
+    if r.endswith('.0') and not ('e' in r.lower() or 'inf' in r.lower()):
+        return r[:-2]
+    # Normalize exponential: 1e-07 -> 1e-7, 1e+07 -> 1e+7
+    r = re.sub(
+        r'e([+-])(\d+)',
+        lambda m: f'e{m.group(1)}{int(m.group(2))}',
+        r,
+    )
+    return r
 
 
 def _parse_es_decimal(value: float) -> Tuple[int, int]:
@@ -289,7 +337,7 @@ def _parse_es_decimal(value: float) -> Tuple[int, int]:
         )
     import decimal
     d = decimal.Decimal(repr(value))
-    sign, digits, exponent = d.as_tuple()
+    _, digits, exponent = d.as_tuple()
     coeff = int("".join(str(i) for i in digits))
     return coeff, exponent
 
@@ -356,56 +404,69 @@ def is_valid_document(document: Mapping[str, Any]) -> bool:
             return False
         if document.get("spec_version") != SPEC_VERSION:
             return False
-        if document.get("verdict") not in {"VERIFIED", "UNVERIFIABLE", "BLOCKED"}:
+        verdict = document.get("verdict")
+        if verdict not in {"VERIFIED", "UNVERIFIABLE", "BLOCKED"}:
+            return False
+        if not _has_required_schema(document):
             return False
 
-        verdict = document["verdict"]
-        obj = document.get("object")
-        if not isinstance(obj, Mapping):
-            return False
-        if not isinstance(obj.get("formal_statement"), str) or not obj.get("formal_statement", "").strip():
-            return False
-
-        context = document.get("context")
-        if not isinstance(context, Mapping):
-            return False
-
-        # Required schema fields
-        if not isinstance(context.get("interpretation"), Mapping):
-            return False
-        if not isinstance(context.get("proof"), Mapping):
-            return False
-        if not isinstance(context.get("evidence"), Mapping):
-            return False
-        if not isinstance(context.get("decision"), Mapping):
-            return False
-
-        decision = context["decision"]
-        admission = decision.get("admission")
-        if admission not in {"ADMIT", "DENY"}:
-            return False
-
+        context = document["context"]
+        admission = context["decision"].get("admission")
         evidence = context["evidence"]
         proof_ref = evidence.get("proof_ref")
 
-        # Verdict/admission invariants
         if verdict == "VERIFIED":
-            if admission != "ADMIT":
-                return False
-            if proof_ref is None or not isinstance(proof_ref, str) or not proof_ref.startswith("sha256:"):
-                return False
-            # FAIL-CLOSED: proof_ref must resolve against the document
-            return resolve_document_proof_ref(document)
-        else:
-            # UNVERIFIABLE/BLOCKED: must DENY, must not have proof_ref
-            if admission != "DENY":
-                return False
-            return proof_ref is None
+            return _is_valid_verified(document, admission, proof_ref)
+        return admission == "DENY" and proof_ref is None
 
     except (VerificationContextValidationError, KeyError, TypeError, AttributeError):
         return False
 
 
+def _has_required_schema(document: Mapping[str, Any]) -> bool:
+    """Check document has required object/context schema fields."""
+
+    obj = document.get("object")
+    if not isinstance(obj, Mapping):
+        return False
+    if not isinstance(obj.get("formal_statement"), str) or not obj.get("formal_statement", "").strip():
+        return False
+    if not isinstance(document.get("context"), Mapping):
+        return False
+
+    context = document["context"]
+    for field in ("interpretation", "proof", "evidence", "decision"):
+        if not isinstance(context.get(field), Mapping):
+            return False
+
+    # Validate structure for ALL verdicts, not just VERIFIED.
+    # Greptile: empty/invalid nested fields must be rejected for UNVERIFIABLE/BLOCKED too.
+    interpretation = context["interpretation"]
+    if not isinstance(interpretation.get("theory"), str) or not interpretation.get("theory", "").strip():
+        return False
+    if not isinstance(interpretation.get("logic"), str) or not interpretation.get("logic", "").strip():
+        return False
+
+    proof = context["proof"]
+    if not isinstance(proof.get("verifier"), str) or not proof.get("verifier", "").strip():
+        return False
+
+    evidence = context["evidence"]
+    payload = evidence.get("payload")
+    if not isinstance(payload, dict) or payload is None:
+        return False
+
+    return True
+
+
+def _is_valid_verified(document: Mapping[str, Any], admission: Optional[str], proof_ref: Optional[str]) -> bool:
+    """Validate VERIFIED document: ADMIT + resolvable proof_ref required."""
+    if admission != "ADMIT":
+        return False
+    if not isinstance(proof_ref, str) or not proof_ref.startswith("sha256:"):
+        return False
+    # FAIL-CLOSED: proof_ref must resolve against the document
+    return resolve_document_proof_ref(document)
 @dataclass(frozen=True)
 class VerificationContextDocument:
     spec_version: str
@@ -415,6 +476,7 @@ class VerificationContextDocument:
     formalization: Optional[Formalization] = None
 
     def __post_init__(self) -> None:
+        object.__setattr__(self, 'object', copy.deepcopy(self.object))
         if self.spec_version != SPEC_VERSION:
             raise VerificationContextValidationError(
                 f"spec_version must be {SPEC_VERSION}"

--- a/qwed_infra/verification_context.py
+++ b/qwed_infra/verification_context.py
@@ -128,6 +128,7 @@ class Proof:
             raise VerificationContextValidationError(
                 "Proof.configuration must be a dict"
             )
+        object.__setattr__(self, 'configuration', copy.deepcopy(self.configuration))
         if not isinstance(self.trusted_dependencies, tuple):
             raise VerificationContextValidationError(
                 "Proof.trusted_dependencies must be a tuple of strings"
@@ -247,25 +248,6 @@ def _canonical_json(value: Any) -> str:
     )
 
 
-def _canonical_json(value: Any) -> str:
-    if value is None:
-        return "null"
-    if isinstance(value, bool):
-        return "true" if value else "false"
-    if isinstance(value, (int, float)):
-        return _canonical_json_number(value)
-    if isinstance(value, str):
-        _reject_unpaired_surrogates(value)
-        return json.dumps(value, ensure_ascii=False)
-    if isinstance(value, (list, tuple)):
-        return "[" + ",".join(_canonical_json(item) for item in value) + "]"
-    if isinstance(value, Mapping):
-        return _canonical_json_mapping(value)
-    raise VerificationContextValidationError(
-        f"unsupported type in proof_ref payload: {type(value).__name__}"
-    )
-
-
 def _canonical_json_number(value) -> str:
     """Serialize int/float to canonical JSON with IEEE-754 float semantics."""
     if isinstance(value, int):
@@ -317,17 +299,40 @@ def _es_number_to_string(value: float) -> str:
         )
     if value == 0:
         return "0"
-    r = repr(value)
-    # Integer-valued floats within ECMAScript safe integer range: strip trailing .0
-    if r.endswith('.0') and not ('e' in r.lower() or 'inf' in r.lower()):
-        return r[:-2]
-    # Normalize exponential: 1e-07 -> 1e-7, 1e+07 -> 1e+7
-    r = re.sub(
-        r'e([+-])(\d+)',
-        lambda m: f'e{m.group(1)}{int(m.group(2))}',
-        r,
-    )
-    return r
+    neg = value < 0
+    abs_val = abs(value)
+    coeff, e10 = _parse_es_decimal(abs_val)
+    if coeff == 0:
+        return "0"
+    # Strip trailing zeros from coefficient and adjust exponent
+    # (e.g., 420, -1 -> 42, 0 so 42.0 serializes as "42")
+    while coeff > 0 and coeff % 10 == 0:
+        coeff //= 10
+        e10 += 1
+    # ECMAScript thresholds: exponential for >= 1e21 or < 1e-6
+    if abs_val >= 1e21 or abs_val < 1e-6:
+        out = _format_es_exponential(coeff, e10)
+    else:
+        out = _format_es_decimal(coeff, e10)
+    if neg:
+        return "-" + out
+    return out
+
+
+def _format_es_exponential(coeff: int, exponent: int) -> str:
+    """Format number in ECMAScript exponential notation (e.g., 1e+21, 1e-7)."""
+    s = str(coeff)
+    if len(s) == 1:
+        mantissa = s
+        exp = exponent
+    else:
+        mantissa = s[0] + "." + s[1:]
+        exp = exponent + len(s) - 1
+    # Strip trailing zeros in mantissa decimal part
+    if "." in mantissa:
+        mantissa = mantissa.rstrip("0").rstrip(".")
+    exp_str = f"e+{exp}" if exp >= 0 else f"e{exp}"
+    return mantissa + exp_str
 
 
 def _parse_es_decimal(value: float) -> Tuple[int, int]:
@@ -335,7 +340,6 @@ def _parse_es_decimal(value: float) -> Tuple[int, int]:
         raise VerificationContextValidationError(
             f"non-finite number not allowed: {value!r}"
         )
-    import decimal
     d = decimal.Decimal(repr(value))
     _, digits, exponent = d.as_tuple()
     coeff = int("".join(str(i) for i in digits))
@@ -370,7 +374,7 @@ def _reject_unpaired_surrogates(value: str) -> None:
 
 
 def compute_document_proof_ref(document: Mapping[str, Any]) -> str:
-    formal_statement = document["object"]["formal_statement"]
+    object_dict = dict(document["object"])
     context_dict = document["context"]
     evidence_dict = {
         key: value
@@ -378,7 +382,7 @@ def compute_document_proof_ref(document: Mapping[str, Any]) -> str:
         if key != "proof_ref"
     }
     bound = {
-        "formal_statement": formal_statement,
+        "object": object_dict,
         "context": {**context_dict, "evidence": evidence_dict},
     }
     payload = _canonical_json(bound)
@@ -448,8 +452,10 @@ def _has_required_schema(document: Mapping[str, Any]) -> bool:
         return False
 
     proof = context["proof"]
-    if not isinstance(proof.get("verifier"), str) or not proof.get("verifier", "").strip():
-        return False
+    for proof_field in ("verifier", "verifier_version", "theory_scope", "outcome_treatment"):
+        val = proof.get(proof_field)
+        if not isinstance(val, str) or not val.strip():
+            return False
 
     evidence = context["evidence"]
     payload = evidence.get("payload")

--- a/qwed_infra/verification_context.py
+++ b/qwed_infra/verification_context.py
@@ -371,18 +371,16 @@ def _format_es_decimal(coeff: int, exponent: int) -> str:
 
 
 def _reject_unpaired_surrogates(value: str) -> None:
+    # Any surrogate code point (paired or unpaired) is rejected: Python str
+    # stores supplementary characters as real scalar values, so any code unit
+    # in the surrogate range cannot be UTF-8 encoded for canonical hashing.
+    # RFC 8785 requires valid Unicode scalar values, which exclude surrogates.
     for i, ch in enumerate(value):
         cp = ord(ch)
-        if 0xD800 <= cp <= 0xDBFF:  # high surrogate
-            if i + 1 >= len(value) or not (0xDC00 <= ord(value[i + 1]) <= 0xDFFF):
-                raise VerificationContextValidationError(
-                    f"unpaired high surrogate at position {i}: {value!r}"
-                )
-        elif 0xDC00 <= cp <= 0xDFFF:  # low surrogate
-            if i == 0 or not (0xD800 <= ord(value[i - 1]) <= 0xDBFF):
-                raise VerificationContextValidationError(
-                    f"unpaired low surrogate at position {i}: {value!r}"
-                )
+        if 0xD800 <= cp <= 0xDFFF:
+            raise VerificationContextValidationError(
+                f"surrogate code point not allowed at position {i}: {value!r}"
+            )
 
 
 def compute_document_proof_ref(document: Mapping[str, Any]) -> str:
@@ -412,7 +410,7 @@ def resolve_document_proof_ref(document: Mapping[str, Any]) -> bool:
         expected = compute_document_proof_ref(document)
         stored = document["context"]["evidence"]["proof_ref"]
         return isinstance(stored, str) and stored == expected
-    except (VerificationContextValidationError, KeyError, TypeError, AttributeError):
+    except (VerificationContextValidationError, KeyError, TypeError, AttributeError, UnicodeError):
         return False
 
 
@@ -437,7 +435,7 @@ def is_valid_document(document: Mapping[str, Any]) -> bool:
             return _is_valid_verified(document, admission, proof_ref)
         return admission == "DENY" and proof_ref is None
 
-    except (VerificationContextValidationError, KeyError, TypeError, AttributeError):
+    except (VerificationContextValidationError, KeyError, TypeError, AttributeError, UnicodeError):
         return False
 
 
@@ -576,6 +574,66 @@ def _is_valid_verified(document: Mapping[str, Any], admission: Optional[str], pr
         return False
     # FAIL-CLOSED: proof_ref must resolve against the document
     return resolve_document_proof_ref(document)
+
+
+def _validate_document_shape(
+    spec_version: str,
+    obj: Dict[str, Any],
+    verdict: Verdict,
+    formalization: Optional[Formalization],
+) -> Any:
+    """Validate static document fields and return the frozen object value."""
+    if formalization is not None and not isinstance(formalization, Formalization):
+        raise VerificationContextValidationError(
+            "formalization must be a Formalization instance or None"
+        )
+    if not isinstance(obj, dict):
+        raise VerificationContextValidationError(
+            "object must be a dict with formal_statement"
+        )
+    if not _is_serializable(obj):
+        raise VerificationContextValidationError(
+            "object contains unsupported non-canonical values"
+        )
+    if spec_version != SPEC_VERSION:
+        raise VerificationContextValidationError(
+            f"spec_version must be {SPEC_VERSION}"
+        )
+    formal_statement = obj.get("formal_statement")
+    if not isinstance(formal_statement, str) or not formal_statement.strip():
+        raise VerificationContextValidationError(
+            "object.formal_statement must be a non-empty string"
+        )
+    if not isinstance(verdict, Verdict):
+        raise VerificationContextValidationError(
+            "verdict must be VERIFIED, UNVERIFIABLE, or BLOCKED"
+        )
+    return _freeze_value(copy.deepcopy(obj))
+
+
+def _validate_document_verdict(verdict: Verdict, context: VerificationContext) -> None:
+    """Validate the verdict/admission/proof_ref contract for the document."""
+    proof_ref = context.evidence.proof_ref
+    if verdict is Verdict.VERIFIED:
+        if proof_ref is None:
+            raise VerificationContextValidationError(
+                "VERIFIED verdict requires context.evidence.proof_ref to be non-null"
+            )
+        if context.decision.admission is Admission.DENY:
+            raise VerificationContextValidationError(
+                "VERIFIED verdict requires ADMIT admission"
+            )
+    else:
+        if proof_ref is not None:
+            raise VerificationContextValidationError(
+                f"{verdict.value} verdict requires proof_ref to be null"
+            )
+        if context.decision.admission is Admission.ADMIT:
+            raise VerificationContextValidationError(
+                f"{verdict.value} verdict requires DENY admission"
+            )
+
+
 @dataclass(frozen=True)
 class VerificationContextDocument:
     spec_version: str
@@ -585,48 +643,17 @@ class VerificationContextDocument:
     formalization: Optional[Formalization] = None
 
     def __post_init__(self) -> None:
-        if self.formalization is not None and not isinstance(self.formalization, Formalization):
-            raise VerificationContextValidationError(
-                "formalization must be a Formalization instance or None"
-            )
-        if not isinstance(self.object, dict):
-            raise VerificationContextValidationError(
-                "object must be a dict with formal_statement"
-            )
-        if not _is_serializable(self.object):
-            raise VerificationContextValidationError(
-                "object contains unsupported non-canonical values"
-            )
-        object.__setattr__(self, 'object', _freeze_value(copy.deepcopy(self.object)))
-        if self.spec_version != SPEC_VERSION:
-            raise VerificationContextValidationError(
-                f"spec_version must be {SPEC_VERSION}"
-            )
-        formal_statement = self.object.get("formal_statement")
-        if not isinstance(formal_statement, str) or not formal_statement.strip():
-            raise VerificationContextValidationError(
-                "object.formal_statement must be a non-empty string"
-            )
-        if not isinstance(self.verdict, Verdict):
-            raise VerificationContextValidationError(
-                "verdict must be VERIFIED, UNVERIFIABLE, or BLOCKED"
-            )
-        if self.verdict is Verdict.VERIFIED and self.context.evidence.proof_ref is None:
-            raise VerificationContextValidationError(
-                "VERIFIED verdict requires context.evidence.proof_ref to be non-null"
-            )
-        if self.verdict is not Verdict.VERIFIED and self.context.evidence.proof_ref is not None:
-            raise VerificationContextValidationError(
-                f"{self.verdict.value} verdict requires proof_ref to be null"
-            )
-        if self.verdict is Verdict.VERIFIED and self.context.decision.admission is Admission.DENY:
-            raise VerificationContextValidationError(
-                "VERIFIED verdict requires ADMIT admission"
-            )
-        if self.verdict is not Verdict.VERIFIED and self.context.decision.admission is Admission.ADMIT:
-            raise VerificationContextValidationError(
-                f"{self.verdict.value} verdict requires DENY admission"
-            )
+        object.__setattr__(
+            self, 'object',
+            _validate_document_shape(self.spec_version, self.object, self.verdict, self.formalization),
+        )
+        _validate_document_verdict(self.verdict, self.context)
+        if self.verdict is Verdict.VERIFIED:
+            if not resolve_document_proof_ref(self.to_dict()):
+                raise VerificationContextValidationError(
+                    "VERIFIED verdict requires context.evidence.proof_ref "
+                    "to bind the document contents"
+                )
 
     def to_dict(self) -> Dict[str, Any]:
         object_dict = _thaw_value(self.object)

--- a/qwed_infra/verification_context.py
+++ b/qwed_infra/verification_context.py
@@ -128,7 +128,7 @@ class Proof:
             raise VerificationContextValidationError(
                 "Proof.configuration must be a dict"
             )
-        object.__setattr__(self, 'configuration', copy.deepcopy(self.configuration))
+        object.__setattr__(self, 'configuration', _freeze_value(copy.deepcopy(self.configuration)))
         if not isinstance(self.trusted_dependencies, tuple):
             raise VerificationContextValidationError(
                 "Proof.trusted_dependencies must be a tuple of strings"
@@ -143,7 +143,7 @@ class Proof:
         return {
             "verifier": self.verifier,
             "verifier_version": self.verifier_version,
-            "configuration": copy.deepcopy(self.configuration),
+            "configuration": _thaw_value(self.configuration),
             "theory_scope": self.theory_scope,
             "trusted_dependencies": list(self.trusted_dependencies),
             "outcome_treatment": self.outcome_treatment,
@@ -160,9 +160,7 @@ class Evidence:
             raise VerificationContextValidationError(
                 "Evidence.payload must be a dict"
             )
-        # Deep-copy the payload to prevent post-construction caller mutation from
-        # affecting the proof-bound document (aliases break proof_ref resolution).
-        object.__setattr__(self, 'payload', copy.deepcopy(self.payload))
+        object.__setattr__(self, 'payload', _freeze_value(copy.deepcopy(self.payload)))
         if self.proof_ref is not None:
             if not isinstance(self.proof_ref, str) or not _PROOF_REF_PATTERN.fullmatch(self.proof_ref):
                 raise VerificationContextValidationError(
@@ -171,7 +169,7 @@ class Evidence:
 
     def to_dict(self) -> Dict[str, Any]:
         return {
-            "payload": copy.deepcopy(self.payload),
+            "payload": _thaw_value(self.payload),
             "proof_ref": self.proof_ref,
         }
 
@@ -382,6 +380,8 @@ def compute_document_proof_ref(document: Mapping[str, Any]) -> str:
         if key != "proof_ref"
     }
     bound = {
+        "spec_version": document["spec_version"],
+        "verdict": document["verdict"],
         "object": object_dict,
         "context": {**context_dict, "evidence": evidence_dict},
     }
@@ -517,14 +517,14 @@ class VerificationContextDocument:
     formalization: Optional[Formalization] = None
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, 'object', copy.deepcopy(self.object))
-        if self.spec_version != SPEC_VERSION:
-            raise VerificationContextValidationError(
-                f"spec_version must be {SPEC_VERSION}"
-            )
         if not isinstance(self.object, dict):
             raise VerificationContextValidationError(
                 "object must be a dict with formal_statement"
+            )
+        object.__setattr__(self, 'object', _freeze_value(copy.deepcopy(self.object)))
+        if self.spec_version != SPEC_VERSION:
+            raise VerificationContextValidationError(
+                f"spec_version must be {SPEC_VERSION}"
             )
         formal_statement = self.object.get("formal_statement")
         if not isinstance(formal_statement, str) or not formal_statement.strip():
@@ -553,7 +553,7 @@ class VerificationContextDocument:
             )
 
     def to_dict(self) -> Dict[str, Any]:
-        object_dict = copy.deepcopy(self.object)
+        object_dict = _thaw_value(self.object)
         if self.formalization is not None:
             object_dict["formalization"] = self.formalization.to_dict()
         doc = {

--- a/qwed_infra/verification_context.py
+++ b/qwed_infra/verification_context.py
@@ -15,9 +15,8 @@ import hashlib
 import json
 import math
 import re
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from enum import Enum
-from functools import lru_cache
 from types import MappingProxyType
 from typing import Any, Dict, Mapping, Optional, Tuple
 
@@ -114,8 +113,12 @@ class Proof:
     outcome_treatment: str
 
     def __post_init__(self) -> None:
-        for field_name in ("verifier", "verifier_version", "theory_scope", "outcome_treatment"):
-            value = getattr(self, field_name)
+        for field_name, value in (
+            ("verifier", self.verifier),
+            ("verifier_version", self.verifier_version),
+            ("theory_scope", self.theory_scope),
+            ("outcome_treatment", self.outcome_treatment),
+        ):
             if not isinstance(value, str) or not value.strip():
                 raise VerificationContextValidationError(
                     f"Proof.{field_name} must be a non-empty string"
@@ -190,17 +193,22 @@ class VerificationContext:
     decision: Decision
 
     def __post_init__(self) -> None:
-        for field_name, expected_type in (
-            ("interpretation", Interpretation),
-            ("proof", Proof),
-            ("evidence", Evidence),
-            ("decision", Decision),
-        ):
-            value = getattr(self, field_name)
-            if not isinstance(value, expected_type):
-                raise VerificationContextValidationError(
-                    f"VerificationContext.{field_name} must be a {expected_type.__name__}"
-                )
+        if not isinstance(self.interpretation, Interpretation):
+            raise VerificationContextValidationError(
+                "VerificationContext.interpretation must be a Interpretation"
+            )
+        if not isinstance(self.proof, Proof):
+            raise VerificationContextValidationError(
+                "VerificationContext.proof must be a Proof"
+            )
+        if not isinstance(self.evidence, Evidence):
+            raise VerificationContextValidationError(
+                "VerificationContext.evidence must be a Evidence"
+            )
+        if not isinstance(self.decision, Decision):
+            raise VerificationContextValidationError(
+                "VerificationContext.decision must be a Decision"
+            )
         if self.evidence.proof_ref is not None and self.decision.admission is Admission.DENY:
             raise VerificationContextValidationError(
                 "DENY admission requires proof_ref is None — "
@@ -350,8 +358,51 @@ def is_valid_document(document: Mapping[str, Any]) -> bool:
             return False
         if document.get("verdict") not in {"VERIFIED", "UNVERIFIABLE", "BLOCKED"}:
             return False
-        return True
-    except (KeyError, TypeError, AttributeError):
+
+        verdict = document["verdict"]
+        obj = document.get("object")
+        if not isinstance(obj, Mapping):
+            return False
+        if not isinstance(obj.get("formal_statement"), str) or not obj.get("formal_statement", "").strip():
+            return False
+
+        context = document.get("context")
+        if not isinstance(context, Mapping):
+            return False
+
+        # Required schema fields
+        if not isinstance(context.get("interpretation"), Mapping):
+            return False
+        if not isinstance(context.get("proof"), Mapping):
+            return False
+        if not isinstance(context.get("evidence"), Mapping):
+            return False
+        if not isinstance(context.get("decision"), Mapping):
+            return False
+
+        decision = context["decision"]
+        admission = decision.get("admission")
+        if admission not in {"ADMIT", "DENY"}:
+            return False
+
+        evidence = context["evidence"]
+        proof_ref = evidence.get("proof_ref")
+
+        # Verdict/admission invariants
+        if verdict == "VERIFIED":
+            if admission != "ADMIT":
+                return False
+            if proof_ref is None or not isinstance(proof_ref, str) or not proof_ref.startswith("sha256:"):
+                return False
+            # FAIL-CLOSED: proof_ref must resolve against the document
+            return resolve_document_proof_ref(document)
+        else:
+            # UNVERIFIABLE/BLOCKED: must DENY, must not have proof_ref
+            if admission != "DENY":
+                return False
+            return proof_ref is None
+
+    except (VerificationContextValidationError, KeyError, TypeError, AttributeError):
         return False
 
 
@@ -399,12 +450,13 @@ class VerificationContextDocument:
             )
 
     def to_dict(self) -> Dict[str, Any]:
+        object_dict = copy.deepcopy(self.object)
+        if self.formalization is not None:
+            object_dict["formalization"] = self.formalization.to_dict()
         doc = {
             "spec_version": self.spec_version,
-            "object": self.object,
+            "object": object_dict,
             "context": self.context.to_dict(),
             "verdict": self.verdict.value,
         }
-        if self.formalization is not None:
-            doc["object"]["formalization"] = self.formalization.to_dict()
         return doc

--- a/qwed_infra/verification_context.py
+++ b/qwed_infra/verification_context.py
@@ -156,13 +156,13 @@ class Evidence:
     proof_ref: Optional[str] = None
 
     def __post_init__(self) -> None:
-        # Deep-copy the payload to prevent post-construction caller mutation from
-        # affecting the proof-bound document (aliases break proof_ref resolution).
-        object.__setattr__(self, 'payload', copy.deepcopy(self.payload))
         if not isinstance(self.payload, dict):
             raise VerificationContextValidationError(
                 "Evidence.payload must be a dict"
             )
+        # Deep-copy the payload to prevent post-construction caller mutation from
+        # affecting the proof-bound document (aliases break proof_ref resolution).
+        object.__setattr__(self, 'payload', copy.deepcopy(self.payload))
         if self.proof_ref is not None:
             if not isinstance(self.proof_ref, str) or not _PROOF_REF_PATTERN.fullmatch(self.proof_ref):
                 raise VerificationContextValidationError(
@@ -429,39 +429,74 @@ def is_valid_document(document: Mapping[str, Any]) -> bool:
 
 def _has_required_schema(document: Mapping[str, Any]) -> bool:
     """Check document has required object/context schema fields."""
+    if not _has_valid_object(document):
+        return False
+    if not _has_valid_context(document):
+        return False
+    return True
 
+
+def _has_valid_object(document: Mapping[str, Any]) -> bool:
     obj = document.get("object")
     if not isinstance(obj, Mapping):
         return False
     if not isinstance(obj.get("formal_statement"), str) or not obj.get("formal_statement", "").strip():
         return False
+    formalization = obj.get("formalization")
+    if formalization is not None:
+        if not isinstance(formalization, Mapping):
+            return False
+        for field in ("source_query", "translator"):
+            val = formalization.get(field)
+            if not isinstance(val, str) or not val.strip():
+                return False
+    return True
+
+
+def _has_valid_context(document: Mapping[str, Any]) -> bool:
     if not isinstance(document.get("context"), Mapping):
         return False
-
     context = document["context"]
     for field in ("interpretation", "proof", "evidence", "decision"):
         if not isinstance(context.get(field), Mapping):
             return False
-
-    # Validate structure for ALL verdicts, not just VERIFIED.
-    # Greptile: empty/invalid nested fields must be rejected for UNVERIFIABLE/BLOCKED too.
-    interpretation = context["interpretation"]
-    if not isinstance(interpretation.get("theory"), str) or not interpretation.get("theory", "").strip():
+    if not _has_valid_interpretation(context["interpretation"]):
         return False
-    if not isinstance(interpretation.get("logic"), str) or not interpretation.get("logic", "").strip():
+    if not _has_valid_proof(context["proof"]):
         return False
+    if not _has_valid_evidence(context["evidence"]):
+        return False
+    return True
 
-    proof = context["proof"]
-    for proof_field in ("verifier", "verifier_version", "theory_scope", "outcome_treatment"):
-        val = proof.get(proof_field)
+
+def _has_valid_interpretation(interp: Mapping[str, Any]) -> bool:
+    for field in ("theory", "logic"):
+        val = interp.get(field)
         if not isinstance(val, str) or not val.strip():
             return False
+    return True
 
-    evidence = context["evidence"]
+
+def _has_valid_proof(proof: Mapping[str, Any]) -> bool:
+    for field in ("verifier", "verifier_version", "theory_scope", "outcome_treatment"):
+        val = proof.get(field)
+        if not isinstance(val, str) or not val.strip():
+            return False
+    if not isinstance(proof.get("configuration"), Mapping):
+        return False
+    deps = proof.get("trusted_dependencies")
+    if not isinstance(deps, list):
+        return False
+    for dep in deps:
+        if not isinstance(dep, str):
+            return False
+    return True
+
+
+def _has_valid_evidence(evidence: Mapping[str, Any]) -> bool:
     payload = evidence.get("payload")
     if not isinstance(payload, dict) or payload is None:
         return False
-
     return True
 
 

--- a/qwed_infra/verification_context.py
+++ b/qwed_infra/verification_context.py
@@ -134,9 +134,9 @@ class Proof:
                 "Proof.trusted_dependencies must be a tuple of strings"
             )
         for dep in self.trusted_dependencies:
-            if not isinstance(dep, str):
+            if not isinstance(dep, str) or not dep.strip():
                 raise VerificationContextValidationError(
-                    "Proof.trusted_dependencies must contain only strings"
+                    "Proof.trusted_dependencies must contain only non-empty strings"
                 )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -477,12 +477,37 @@ def _has_valid_interpretation(interp: Mapping[str, Any]) -> bool:
     return True
 
 
+def _is_serializable(value: Any) -> bool:
+    """Recursively check value is representable by _canonical_json (RFC 8785)."""
+    if value is None or isinstance(value, bool):
+        return True
+    if isinstance(value, int):
+        return _is_safe_integer(value)
+    if isinstance(value, float):
+        return math.isfinite(value)
+    if isinstance(value, str):
+        try:
+            _reject_unpaired_surrogates(value)
+            return True
+        except VerificationContextValidationError:
+            return False
+    if isinstance(value, (list, tuple)):
+        return all(_is_serializable(item) for item in value)
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if not isinstance(key, str) or not _is_serializable(item):
+                return False
+        return True
+    return False
+
+
 def _has_valid_proof(proof: Mapping[str, Any]) -> bool:
     for field in ("verifier", "verifier_version", "theory_scope", "outcome_treatment"):
         val = proof.get(field)
         if not isinstance(val, str) or not val.strip():
             return False
-    if not isinstance(proof.get("configuration"), Mapping):
+    config = proof.get("configuration")
+    if not isinstance(config, Mapping) or not _is_serializable(config):
         return False
     deps = proof.get("trusted_dependencies")
     if not isinstance(deps, list):
@@ -495,7 +520,7 @@ def _has_valid_proof(proof: Mapping[str, Any]) -> bool:
 
 def _has_valid_evidence(evidence: Mapping[str, Any]) -> bool:
     payload = evidence.get("payload")
-    if not isinstance(payload, dict) or payload is None:
+    if not isinstance(payload, dict) or not _is_serializable(payload):
         return False
     return True
 

--- a/qwed_infra/verification_context_bridge.py
+++ b/qwed_infra/verification_context_bridge.py
@@ -19,6 +19,7 @@ from .verification_context import (
     Formalization,
     Interpretation,
     Proof,
+    SPEC_VERSION,
     Verdict,
     VerificationContext,
     VerificationContextDocument,
@@ -70,6 +71,13 @@ def verification_context_from_diagnostic_result(
             },
         )
 
+    if attestation_token is not None and (
+        not isinstance(attestation_token, str) or not attestation_token.strip()
+    ):
+        raise VerificationContextValidationError(
+            "attestation_token must be a non-empty string or None"
+        )
+
     if result.status is InfraDiagnosticStatus.VERIFIED and attestation_token is None:
         # Fail-closed: VERIFIED requires attestation to maintain authority;
         # without it, demote to UNVERIFIABLE (consistent with core contract).
@@ -82,7 +90,7 @@ def verification_context_from_diagnostic_result(
     proof = Proof(
         verifier=verifier,
         verifier_version=_resolved_verifier_version(verifier_version),
-        configuration={},
+        configuration={} if attestation_token is None else {"attestation": "present"},
         theory_scope=f"{verifier} deterministic verification",
         trusted_dependencies=("qwed-infra",),
         outcome_treatment="unknown/timeout/error resolve to UNVERIFIABLE or BLOCKED",
@@ -92,13 +100,30 @@ def verification_context_from_diagnostic_result(
         translator=verifier,
     )
 
+    # Build evidence payload: preserve diagnostic fields, keep diagnostic proof_ref
+    # under a NESTED key (diagnostic_proof_ref) to avoid conflict with document proof_ref.
     evidence_payload = copy.deepcopy(result.to_dict())
-    # Exclude proof_ref from bound payload (it commits to itself)
-    evidence_payload.pop("proof_ref", None)
+    diagnostic_proof_ref = evidence_payload.pop("proof_ref", None)
+    if diagnostic_proof_ref is not None:
+        evidence_payload["diagnostic_proof_ref"] = diagnostic_proof_ref
 
     if result.status is InfraDiagnosticStatus.VERIFIED:
         decision = Decision(admission=Admission.ADMIT)
-        proof_ref = result.proof_ref
+        # Assemble context WITHOUT proof_ref to compute document-level hash,
+        # then set proof_ref from the assembled document.
+        from .verification_context import compute_document_proof_ref
+        doc_for_hash = {
+            "spec_version": SPEC_VERSION,
+            "object": {"formal_statement": formal_statement},
+            "context": {
+                "interpretation": interpretation.to_dict(),
+                "proof": proof.to_dict(),
+                "evidence": {"payload": evidence_payload, "proof_ref": None},
+                "decision": decision.to_dict(),
+            },
+            "verdict": Verdict.VERIFIED.value,
+        }
+        proof_ref = compute_document_proof_ref(doc_for_hash)
     else:
         decision = Decision(admission=Admission.DENY)
         proof_ref = None
@@ -110,16 +135,14 @@ def verification_context_from_diagnostic_result(
         decision=decision,
     )
 
-    verdict_map = {
-        InfraDiagnosticStatus.VERIFIED: Verdict.VERIFIED,
-        InfraDiagnosticStatus.UNVERIFIABLE: Verdict.UNVERIFIABLE,
-        InfraDiagnosticStatus.BLOCKED: Verdict.BLOCKED,
-    }
-
     return VerificationContextDocument(
-        spec_version="1.0",
+        spec_version=SPEC_VERSION,
         object={"formal_statement": formal_statement},
         context=context,
-        verdict=verdict_map[result.status],
+        verdict={
+            InfraDiagnosticStatus.VERIFIED: Verdict.VERIFIED,
+            InfraDiagnosticStatus.UNVERIFIABLE: Verdict.UNVERIFIABLE,
+            InfraDiagnosticStatus.BLOCKED: Verdict.BLOCKED,
+        }[result.status],
         formalization=formalization,
     )

--- a/qwed_infra/verification_context_bridge.py
+++ b/qwed_infra/verification_context_bridge.py
@@ -89,13 +89,19 @@ def _normalize_developer_fields(result):
 
 
 def _apply_attestation_policy(result, attestation_token):
-    """Demote VERIFIED to UNVERIFIABLE when attestation token is missing."""
+    """Demote VERIFIED to UNVERIFIABLE when attestation token is missing.
+
+    Returns (decision_result, evidence_result). The evidence result retains the
+    original diagnostic fields (including proof_ref) so the audit trail is
+    preserved even when the verdict is demoted.
+    """
     if result.status is InfraDiagnosticStatus.VERIFIED and attestation_token is None:
-        return InfraDiagnosticResult.unverifiable(
+        decision_result = InfraDiagnosticResult.unverifiable(
             agent_message=result.agent_message,
             developer_fields=result.developer_fields,
         )
-    return result
+        return decision_result, result
+    return result, result
 
 
 def _build_evidence_payload(result):
@@ -146,7 +152,7 @@ def verification_context_from_diagnostic_result(
 
     result = _normalize_status(result)
     result = _normalize_developer_fields(result)
-    result = _apply_attestation_policy(result, attestation_token)
+    decision_result, evidence_result = _apply_attestation_policy(result, attestation_token)
 
     interpretation = Interpretation(theory=f"{verifier} verification")
     proof = Proof(
@@ -162,9 +168,9 @@ def verification_context_from_diagnostic_result(
         translator=verifier,
     )
 
-    evidence_payload = _build_evidence_payload(result)
+    evidence_payload = _build_evidence_payload(evidence_result)
 
-    if result.status is InfraDiagnosticStatus.VERIFIED:
+    if decision_result.status is InfraDiagnosticStatus.VERIFIED:
         decision = Decision(admission=Admission.ADMIT)
         proof_ref = _compute_verified_proof_ref(
             formal_statement, interpretation, proof, evidence_payload, decision, formalization
@@ -184,6 +190,6 @@ def verification_context_from_diagnostic_result(
         spec_version=SPEC_VERSION,
         object={"formal_statement": formal_statement},
         context=context,
-        verdict=_VERDICT_MAP[result.status],
+        verdict=_VERDICT_MAP[decision_result.status],
         formalization=formalization,
     )

--- a/qwed_infra/verification_context_bridge.py
+++ b/qwed_infra/verification_context_bridge.py
@@ -42,14 +42,7 @@ def _resolved_verifier_version(verifier_version: Optional[str]) -> str:
         return qwed_infra_version
 
 
-def verification_context_from_diagnostic_result(
-    result: InfraDiagnosticResult,
-    *,
-    formal_statement: str,
-    verifier: str,
-    verifier_version: Optional[str] = None,
-    attestation_token: Optional[str] = None,
-) -> VerificationContextDocument:
+def _validate_inputs(result, formal_statement, verifier, attestation_token):
     if not isinstance(formal_statement, str) or not formal_statement.strip():
         raise VerificationContextValidationError(
             "formal_statement must be a non-empty string"
@@ -62,35 +55,6 @@ def verification_context_from_diagnostic_result(
         raise VerificationContextValidationError(
             f"result must be an InfraDiagnosticResult, got {type(result).__name__}"
         )
-
-    # Fail-closed: cast malformed status values to the enum before verdict lookup,
-    # so strings like "VERIFIED" produce BLOCKED instead of mapping error.
-    try:
-        result_status = InfraDiagnosticStatus(result.status)
-    except ValueError:
-        result_status = InfraDiagnosticStatus.BLOCKED
-
-    # Rebuild the result with the cast enum status, so to_dict() works correctly.
-    # If the status isn't the enum instance, we always rebuild with the cast enum.
-    if result_status is not result.status:
-        per_status_update = InfraDiagnosticResult.blocked(
-            agent_message=f"Malformed status {result.status!r} demoted to BLOCKED",
-            developer_fields={"constraint_id": "verification_context.malformed_status"},
-        )
-    else:
-        per_status_update = result
-    result = per_status_update
-
-    result = per_status_update
-
-    if not isinstance(result.developer_fields, dict):
-        result = InfraDiagnosticResult.blocked(
-            agent_message="Diagnostic result is malformed",
-            developer_fields={
-                "constraint_id": "verification_context.malformed_developer_fields",
-            },
-        )
-
     if attestation_token is not None and (
         not isinstance(attestation_token, str) or not attestation_token.strip()
     ):
@@ -98,13 +62,91 @@ def verification_context_from_diagnostic_result(
             "attestation_token must be a non-empty string or None"
         )
 
+
+def _normalize_status(result):
+    """Cast malformed status to enum; rebuild as BLOCKED if not an enum instance."""
+    try:
+        result_status = InfraDiagnosticStatus(result.status)
+    except ValueError:
+        result_status = InfraDiagnosticStatus.BLOCKED
+    if result_status is not result.status:
+        return InfraDiagnosticResult.blocked(
+            agent_message=f"Malformed status {result.status!r} demoted to BLOCKED",
+            developer_fields={"constraint_id": "verification_context.malformed_status"},
+        )
+    return result
+
+
+def _normalize_developer_fields(result):
+    if not isinstance(result.developer_fields, dict):
+        return InfraDiagnosticResult.blocked(
+            agent_message="Diagnostic result is malformed",
+            developer_fields={
+                "constraint_id": "verification_context.malformed_developer_fields",
+            },
+        )
+    return result
+
+
+def _apply_attestation_policy(result, attestation_token):
+    """Demote VERIFIED to UNVERIFIABLE when attestation token is missing."""
     if result.status is InfraDiagnosticStatus.VERIFIED and attestation_token is None:
-        # Fail-closed: VERIFIED requires attestation to maintain authority;
-        # without it, demote to UNVERIFIABLE (consistent with core contract).
-        result = InfraDiagnosticResult.unverifiable(
+        return InfraDiagnosticResult.unverifiable(
             agent_message=result.agent_message,
             developer_fields=result.developer_fields,
         )
+    return result
+
+
+def _build_evidence_payload(result):
+    """Deep-copy result dict, move diagnostic proof_ref to nested key."""
+    evidence_payload = copy.deepcopy(result.to_dict())
+    diagnostic_proof_ref = evidence_payload.pop("proof_ref", None)
+    if diagnostic_proof_ref is not None:
+        evidence_payload["diagnostic_proof_ref"] = diagnostic_proof_ref
+    return evidence_payload
+
+
+def _compute_verified_proof_ref(formal_statement, interpretation, proof, evidence_payload, decision, formalization):
+    """Compute document-bound proof_ref for VERIFIED documents."""
+    from .verification_context import compute_document_proof_ref
+    obj = {"formal_statement": formal_statement}
+    if formalization is not None:
+        obj["formalization"] = formalization.to_dict()
+    doc_for_hash = {
+        "spec_version": SPEC_VERSION,
+        "object": obj,
+        "context": {
+            "interpretation": interpretation.to_dict(),
+            "proof": proof.to_dict(),
+            "evidence": {"payload": evidence_payload, "proof_ref": None},
+            "decision": decision.to_dict(),
+        },
+        "verdict": Verdict.VERIFIED.value,
+    }
+    return compute_document_proof_ref(doc_for_hash)
+
+
+_VERDICT_MAP = {
+    InfraDiagnosticStatus.VERIFIED: Verdict.VERIFIED,
+    InfraDiagnosticStatus.UNVERIFIABLE: Verdict.UNVERIFIABLE,
+    InfraDiagnosticStatus.BLOCKED: Verdict.BLOCKED,
+}
+
+
+def verification_context_from_diagnostic_result(
+    result: InfraDiagnosticResult,
+    *,
+    formal_statement: str,
+    verifier: str,
+    verifier_version: Optional[str] = None,
+    attestation_token: Optional[str] = None,
+) -> VerificationContextDocument:
+    _validate_inputs(result, formal_statement, verifier, attestation_token)
+
+    result = _normalize_status(result)
+    result = _normalize_developer_fields(result)
+    result = _apply_attestation_policy(result, attestation_token)
 
     interpretation = Interpretation(theory=f"{verifier} verification")
     proof = Proof(
@@ -120,30 +162,13 @@ def verification_context_from_diagnostic_result(
         translator=verifier,
     )
 
-    # Build evidence payload: preserve diagnostic fields, keep diagnostic proof_ref
-    # under a NESTED key (diagnostic_proof_ref) to avoid conflict with document proof_ref.
-    evidence_payload = copy.deepcopy(result.to_dict())
-    diagnostic_proof_ref = evidence_payload.pop("proof_ref", None)
-    if diagnostic_proof_ref is not None:
-        evidence_payload["diagnostic_proof_ref"] = diagnostic_proof_ref
+    evidence_payload = _build_evidence_payload(result)
 
     if result.status is InfraDiagnosticStatus.VERIFIED:
         decision = Decision(admission=Admission.ADMIT)
-        # Assemble context WITHOUT proof_ref to compute document-level hash,
-        # then set proof_ref from the assembled document.
-        from .verification_context import compute_document_proof_ref
-        doc_for_hash = {
-            "spec_version": SPEC_VERSION,
-            "object": {"formal_statement": formal_statement},
-            "context": {
-                "interpretation": interpretation.to_dict(),
-                "proof": proof.to_dict(),
-                "evidence": {"payload": evidence_payload, "proof_ref": None},
-                "decision": decision.to_dict(),
-            },
-            "verdict": Verdict.VERIFIED.value,
-        }
-        proof_ref = compute_document_proof_ref(doc_for_hash)
+        proof_ref = _compute_verified_proof_ref(
+            formal_statement, interpretation, proof, evidence_payload, decision, formalization
+        )
     else:
         decision = Decision(admission=Admission.DENY)
         proof_ref = None
@@ -159,10 +184,6 @@ def verification_context_from_diagnostic_result(
         spec_version=SPEC_VERSION,
         object={"formal_statement": formal_statement},
         context=context,
-        verdict={
-            InfraDiagnosticStatus.VERIFIED: Verdict.VERIFIED,
-            InfraDiagnosticStatus.UNVERIFIABLE: Verdict.UNVERIFIABLE,
-            InfraDiagnosticStatus.BLOCKED: Verdict.BLOCKED,
-        }[result.status],
+        verdict=_VERDICT_MAP[result.status],
         formalization=formalization,
     )

--- a/qwed_infra/verification_context_bridge.py
+++ b/qwed_infra/verification_context_bridge.py
@@ -63,6 +63,26 @@ def verification_context_from_diagnostic_result(
             f"result must be an InfraDiagnosticResult, got {type(result).__name__}"
         )
 
+    # Fail-closed: cast malformed status values to the enum before verdict lookup,
+    # so strings like "VERIFIED" produce BLOCKED instead of mapping error.
+    try:
+        result_status = InfraDiagnosticStatus(result.status)
+    except ValueError:
+        result_status = InfraDiagnosticStatus.BLOCKED
+
+    # Rebuild the result with the cast enum status, so to_dict() works correctly.
+    # If the status isn't the enum instance, we always rebuild with the cast enum.
+    if result_status is not result.status:
+        per_status_update = InfraDiagnosticResult.blocked(
+            agent_message=f"Malformed status {result.status!r} demoted to BLOCKED",
+            developer_fields={"constraint_id": "verification_context.malformed_status"},
+        )
+    else:
+        per_status_update = result
+    result = per_status_update
+
+    result = per_status_update
+
     if not isinstance(result.developer_fields, dict):
         result = InfraDiagnosticResult.blocked(
             agent_message="Diagnostic result is malformed",

--- a/qwed_infra/verification_context_bridge.py
+++ b/qwed_infra/verification_context_bridge.py
@@ -1,0 +1,125 @@
+"""
+QWED-Infra Verification Context Bridge.
+
+Converts InfraDiagnosticResult to Verification Context v1.0 document.
+Mirrors qwed-verification/src/qwed_new/core/verification_context_bridge.py.
+"""
+
+from __future__ import annotations
+
+import copy
+from importlib.metadata import PackageNotFoundError, version
+from typing import Optional
+
+from .diagnostics import InfraDiagnosticResult, InfraDiagnosticStatus
+from .verification_context import (
+    Admission,
+    Decision,
+    Evidence,
+    Formalization,
+    Interpretation,
+    Proof,
+    Verdict,
+    VerificationContext,
+    VerificationContextDocument,
+    VerificationContextValidationError,
+)
+
+
+def _resolved_verifier_version(verifier_version: Optional[str]) -> str:
+    if verifier_version is not None:
+        if not verifier_version.strip():
+            raise VerificationContextValidationError(
+                "verifier_version must be non-empty"
+            )
+        return verifier_version
+    try:
+        return version("qwed-infra")
+    except PackageNotFoundError:
+        from qwed_infra import __version__ as qwed_infra_version
+
+        return qwed_infra_version
+
+
+def verification_context_from_diagnostic_result(
+    result: InfraDiagnosticResult,
+    *,
+    formal_statement: str,
+    verifier: str,
+    verifier_version: Optional[str] = None,
+    attestation_token: Optional[str] = None,
+) -> VerificationContextDocument:
+    if not isinstance(formal_statement, str) or not formal_statement.strip():
+        raise VerificationContextValidationError(
+            "formal_statement must be a non-empty string"
+        )
+    if not isinstance(verifier, str) or not verifier.strip():
+        raise VerificationContextValidationError(
+            "verifier must be a non-empty string"
+        )
+    if not isinstance(result, InfraDiagnosticResult):
+        raise VerificationContextValidationError(
+            f"result must be an InfraDiagnosticResult, got {type(result).__name__}"
+        )
+
+    if not isinstance(result.developer_fields, dict):
+        result = InfraDiagnosticResult.blocked(
+            agent_message="Diagnostic result is malformed",
+            developer_fields={
+                "constraint_id": "verification_context.malformed_developer_fields",
+            },
+        )
+
+    if result.status is InfraDiagnosticStatus.VERIFIED and attestation_token is None:
+        # Fail-closed: VERIFIED requires attestation to maintain authority;
+        # without it, demote to UNVERIFIABLE (consistent with core contract).
+        result = InfraDiagnosticResult.unverifiable(
+            agent_message=result.agent_message,
+            developer_fields=result.developer_fields,
+        )
+
+    interpretation = Interpretation(theory=f"{verifier} verification")
+    proof = Proof(
+        verifier=verifier,
+        verifier_version=_resolved_verifier_version(verifier_version),
+        configuration={},
+        theory_scope=f"{verifier} deterministic verification",
+        trusted_dependencies=("qwed-infra",),
+        outcome_treatment="unknown/timeout/error resolve to UNVERIFIABLE or BLOCKED",
+    )
+    formalization = Formalization(
+        source_query=formal_statement,
+        translator=verifier,
+    )
+
+    evidence_payload = copy.deepcopy(result.to_dict())
+    # Exclude proof_ref from bound payload (it commits to itself)
+    evidence_payload.pop("proof_ref", None)
+
+    if result.status is InfraDiagnosticStatus.VERIFIED:
+        decision = Decision(admission=Admission.ADMIT)
+        proof_ref = result.proof_ref
+    else:
+        decision = Decision(admission=Admission.DENY)
+        proof_ref = None
+
+    context = VerificationContext(
+        interpretation=interpretation,
+        proof=proof,
+        evidence=Evidence(payload=evidence_payload, proof_ref=proof_ref),
+        decision=decision,
+    )
+
+    verdict_map = {
+        InfraDiagnosticStatus.VERIFIED: Verdict.VERIFIED,
+        InfraDiagnosticStatus.UNVERIFIABLE: Verdict.UNVERIFIABLE,
+        InfraDiagnosticStatus.BLOCKED: Verdict.BLOCKED,
+    }
+
+    return VerificationContextDocument(
+        spec_version="1.0",
+        object={"formal_statement": formal_statement},
+        context=context,
+        verdict=verdict_map[result.status],
+        formalization=formalization,
+    )

--- a/qwed_infra/verification_context_bridge.py
+++ b/qwed_infra/verification_context_bridge.py
@@ -63,6 +63,30 @@ def _validate_inputs(result, formal_statement, verifier, attestation_token):
         )
 
 
+def _cast_status_preserving(result):
+    """Return a copy of result with a valid enum status and dict developer_fields.
+
+    Used for the audit-trail evidence path when the input is malformed (e.g. a
+    string status or non-dict developer_fields). The reconstructed result keeps
+    the original proof_ref and (when dict) developer_fields so evidence
+    serialization retains the full diagnostic history.
+    """
+    try:
+        result_status = InfraDiagnosticStatus(result.status)
+    except ValueError:
+        result_status = InfraDiagnosticStatus.BLOCKED
+    dev = getattr(result, 'developer_fields', None)
+    valid_dev = dev if isinstance(dev, dict) else {}
+    if result_status is result.status and valid_dev is dev:
+        return result
+    rebuilt = object.__new__(InfraDiagnosticResult)
+    object.__setattr__(rebuilt, 'status', result_status)
+    object.__setattr__(rebuilt, 'agent_message', getattr(result, 'agent_message', ''))
+    object.__setattr__(rebuilt, 'developer_fields', valid_dev)
+    object.__setattr__(rebuilt, 'proof_ref', getattr(result, 'proof_ref', None))
+    return rebuilt
+
+
 def _normalize_status(result):
     """Cast malformed status to enum; rebuild as BLOCKED if not an enum instance."""
     try:
@@ -89,19 +113,13 @@ def _normalize_developer_fields(result):
 
 
 def _apply_attestation_policy(result, attestation_token):
-    """Demote VERIFIED to UNVERIFIABLE when attestation token is missing.
-
-    Returns (decision_result, evidence_result). The evidence result retains the
-    original diagnostic fields (including proof_ref) so the audit trail is
-    preserved even when the verdict is demoted.
-    """
+    """Demote VERIFIED to UNVERIFIABLE when attestation token is missing."""
     if result.status is InfraDiagnosticStatus.VERIFIED and attestation_token is None:
-        decision_result = InfraDiagnosticResult.unverifiable(
+        return InfraDiagnosticResult.unverifiable(
             agent_message=result.agent_message,
             developer_fields=result.developer_fields,
         )
-        return decision_result, result
-    return result, result
+    return result
 
 
 def _build_evidence_payload(result):
@@ -150,9 +168,10 @@ def verification_context_from_diagnostic_result(
 ) -> VerificationContextDocument:
     _validate_inputs(result, formal_statement, verifier, attestation_token)
 
-    result = _normalize_status(result)
-    result = _normalize_developer_fields(result)
-    decision_result, evidence_result = _apply_attestation_policy(result, attestation_token)
+    evidence_result = _cast_status_preserving(result)
+    decision_result = _normalize_status(result)
+    decision_result = _normalize_developer_fields(decision_result)
+    decision_result = _apply_attestation_policy(decision_result, attestation_token)
 
     interpretation = Interpretation(theory=f"{verifier} verification")
     proof = Proof(

--- a/tests/test_verification_context.py
+++ b/tests/test_verification_context.py
@@ -48,6 +48,10 @@ class TestFormalization:
         with pytest.raises(VerificationContextValidationError):
             Formalization(source_query="test", translator="")
 
+    def test_surrogate_in_source_query_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            Formalization(source_query="bad\ud800", translator="TestVerifier")
+
 
 class TestInterpretation:
     def test_valid(self):
@@ -67,6 +71,10 @@ class TestInterpretation:
     def test_empty_logic_rejected(self):
         with pytest.raises(VerificationContextValidationError):
             Interpretation(theory="test", logic="")
+
+    def test_surrogate_in_theory_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            Interpretation(theory="bad\ud800")
 
 
 class TestProof:
@@ -761,11 +769,12 @@ class TestBridge:
     def test_malformed_status_blocked_fail_closed(self):
         # Malformed string status ("VERIFIED" as string) must produce BLOCKED
         # as fail-closed protection (no AttributeError through the bridge).
+        original_ref = "sha256:" + "a" * 64
         result = object.__new__(InfraDiagnosticResult)
         object.__setattr__(result, 'status', "VERIFIED")  # string, not enum
         object.__setattr__(result, 'agent_message', "test")
         object.__setattr__(result, 'developer_fields', {"test": 1})
-        object.__setattr__(result, 'proof_ref', "sha256:" + "a" * 64)
+        object.__setattr__(result, 'proof_ref', original_ref)
 
         vc = verification_context_from_diagnostic_result(
             result,
@@ -775,6 +784,8 @@ class TestBridge:
         # Malformed status demotes to BLOCKED, not ADMIT
         assert vc.verdict == Verdict.BLOCKED
         assert vc.context.decision.admission == Admission.DENY
+        # Audit trail preserved: original proof_ref retained in evidence payload
+        assert vc.context.evidence.payload.get("diagnostic_proof_ref") == original_ref
 
     def test_empty_verifier_rejected(self):
         result = self._verified_result()

--- a/tests/test_verification_context.py
+++ b/tests/test_verification_context.py
@@ -169,8 +169,9 @@ class TestVerificationContext:
         assert ctx.decision.admission == Admission.DENY
 
     def test_deny_with_proof_ref_rejected(self):
+        proof_ref = "sha256:" + "a" * 64
         with pytest.raises(VerificationContextValidationError):
-            self._context(admitted=False, proof_ref="sha256:" + "a" * 64)
+            self._context(admitted=False, proof_ref=proof_ref)
 
     def test_dict_serialization(self):
         ctx = self._context()
@@ -241,25 +242,29 @@ class TestVerificationContextDocument:
             self._doc(verdict=Verdict.VERIFIED, proof_ref=None)
 
     def test_unverified_with_proof_ref_rejected(self):
+        proof_ref = "sha256:" + "a" * 64
         with pytest.raises(VerificationContextValidationError):
-            self._doc(verdict=Verdict.UNVERIFIABLE, proof_ref="sha256:" + "a" * 64)
+            self._doc(verdict=Verdict.UNVERIFIABLE, proof_ref=proof_ref)
 
-    def test_deny_with_verified_rejected(self):
+    def test_admit_with_unverified_verdict_rejected(self):
+        # UNVERIFIABLE verdict requires DENY admission; ADMIT with non-VERIFIED
+        # verdict must fail in VerificationContextDocument.__post_init__.
+        context = VerificationContext(
+            interpretation=Interpretation(theory="Test"),
+            proof=Proof(
+                verifier="Test", verifier_version="1.0",
+                configuration={}, theory_scope="test",
+                trusted_dependencies=(), outcome_treatment="fail-closed",
+            ),
+            evidence=Evidence(payload={"test": True}, proof_ref=None),
+            decision=Decision(admission=Admission.ADMIT),
+        )
         with pytest.raises(VerificationContextValidationError):
             VerificationContextDocument(
                 spec_version="1.0",
                 object={"formal_statement": "test"},
-                context=VerificationContext(
-                    interpretation=Interpretation(theory="Test"),
-                    proof=Proof(
-                        verifier="Test", verifier_version="1.0",
-                        configuration={}, theory_scope="test",
-                        trusted_dependencies=(), outcome_treatment="fail-closed",
-                    ),
-                    evidence=Evidence(payload={"test": True}, proof_ref="sha256:" + "a" * 64),
-                    decision=Decision(admission=Admission.DENY),
-                ),
-                verdict=Verdict.VERIFIED,
+                context=context,
+                verdict=Verdict.UNVERIFIABLE,
             )
 
     def test_dict_serialization(self):
@@ -400,60 +405,25 @@ class TestIsValidDocument:
             "verdict": verdict,
         }
 
-    def test_invalid_missing_object_rejected(self):
-        doc = {"spec_version": "1.0", "verdict": "VERIFIED"}
+    def test_empty_trusted_dependency_rejected(self):
+        doc = self._full_doc(verdict="BLOCKED", admission="DENY", proof_ref=None)
+        doc["context"]["proof"]["trusted_dependencies"] = [""]
         assert is_valid_document(doc) is False
 
-    def test_invalid_missing_context_rejected(self):
-        doc = {"spec_version": "1.0", "object": {"formal_statement": "test"}, "verdict": "VERIFIED"}
+    def test_whitespace_trusted_dependency_rejected(self):
+        doc = self._full_doc(verdict="BLOCKED", admission="DENY", proof_ref=None)
+        doc["context"]["proof"]["trusted_dependencies"] = [" "]
         assert is_valid_document(doc) is False
 
-    def test_invalid_missing_evidence_rejected(self):
-        doc = {
-            "spec_version": "1.0",
-            "object": {"formal_statement": "test"},
-            "context": {
-                "interpretation": {},
-                "proof": {},
-                "decision": {"admission": "ADMIT"},
-            },
-            "verdict": "VERIFIED",
-        }
+    def test_unserializable_config_rejected(self):
+        doc = self._full_doc(verdict="BLOCKED", admission="DENY", proof_ref=None)
+        doc["context"]["proof"]["configuration"] = {"bad": object()}
         assert is_valid_document(doc) is False
 
-    def test_invalid_verified_without_proof_ref_rejected(self):
-        doc = self._full_doc(verdict="VERIFIED", admission="ADMIT", proof_ref=None)
+    def test_unserializable_payload_rejected(self):
+        doc = self._full_doc(verdict="BLOCKED", admission="DENY", proof_ref=None)
+        doc["context"]["evidence"]["payload"] = {"bad": object()}
         assert is_valid_document(doc) is False
-
-    def test_invalid_non_verified_with_proof_ref_rejected(self):
-        doc = self._full_doc(verdict="BLOCKED", admission="DENY", proof_ref="sha256:" + "a" * 64)
-        assert is_valid_document(doc) is False
-
-    def test_invalid_spec_version_rejected(self):
-        doc = self._full_doc()
-        doc["spec_version"] = "2.0"
-        assert is_valid_document(doc) is False
-
-    def test_invalid_verdict_rejected(self):
-        doc = self._full_doc()
-        doc["verdict"] = "INVALID"
-        assert is_valid_document(doc) is False
-
-    def test_non_dict_rejected(self):
-        assert is_valid_document("not-a-dict") is False
-
-    def _full_doc(self, verdict="VERIFIED", admission="ADMIT", proof_ref="sha256:" + "a" * 64):
-        return {
-            "spec_version": "1.0",
-            "object": {"formal_statement": "test claim"},
-            "context": {
-                "interpretation": {"theory": "Test", "logic": "deterministic"},
-                "proof": {"verifier": "Test", "verifier_version": "1.0", "configuration": {}, "theory_scope": "test", "trusted_dependencies": [], "outcome_treatment": "fail-closed"},
-                "evidence": {"payload": {"test": True}, "proof_ref": proof_ref},
-                "decision": {"admission": admission},
-            },
-            "verdict": verdict,
-        }
 
 
 # =============================================================================

--- a/tests/test_verification_context.py
+++ b/tests/test_verification_context.py
@@ -1,0 +1,767 @@
+"""
+Tests for qwed_infra.verification_context model and verification_context_bridge.
+"""
+
+import pytest
+
+from qwed_infra.diagnostics import InfraDiagnosticResult, InfraDiagnosticStatus
+from qwed_infra.verification_context import (
+    Admission,
+    Decision,
+    Evidence,
+    Formalization,
+    Interpretation,
+    Proof,
+    Verdict,
+    VerificationContext,
+    VerificationContextDocument,
+    VerificationContextValidationError,
+    compute_document_proof_ref,
+    is_valid_document,
+    resolve_document_proof_ref,
+)
+from qwed_infra.verification_context_bridge import (
+    verification_context_from_diagnostic_result,
+)
+
+
+# =============================================================================
+# Model type tests
+# =============================================================================
+
+class TestFormalization:
+    def test_valid(self):
+        f = Formalization(source_query="test", translator="TestVerifier")
+        assert f.source_query == "test"
+        assert f.translator == "TestVerifier"
+
+    def test_dict_serialization(self):
+        f = Formalization(source_query="test", translator="TestVerifier")
+        d = f.to_dict()
+        assert d == {"source_query": "test", "translator": "TestVerifier"}
+
+    def test_empty_source_query_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            Formalization(source_query="", translator="TestVerifier")
+
+    def test_empty_translator_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            Formalization(source_query="test", translator="")
+
+
+class TestInterpretation:
+    def test_valid(self):
+        i = Interpretation(theory="TestGuard verification")
+        assert i.theory == "TestGuard verification"
+        assert i.logic == "deterministic pattern matching"
+
+    def test_dict_serialization(self):
+        i = Interpretation(theory="Test", logic="custom logic")
+        d = i.to_dict()
+        assert d == {"theory": "Test", "logic": "custom logic"}
+
+    def test_empty_theory_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            Interpretation(theory="")
+
+    def test_empty_logic_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            Interpretation(theory="test", logic="")
+
+
+class TestProof:
+    def _proof(self):
+        return Proof(
+            verifier="TestGuard", verifier_version="1.0.0",
+            configuration={}, theory_scope="TestGuard tests",
+            trusted_dependencies=("qwed-infra",),
+            outcome_treatment="fail-closed",
+        )
+
+    def test_valid(self):
+        p = self._proof()
+        assert p.verifier == "TestGuard"
+
+    def test_dict_serialization(self):
+        p = self._proof()
+        d = p.to_dict()
+        assert d["verifier"] == "TestGuard"
+        assert d["verifier_version"] == "1.0.0"
+
+    def test_non_dict_config_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            Proof(
+                verifier="Test", verifier_version="1.0.0",
+                configuration="not-a-dict", theory_scope="scope",
+                trusted_dependencies=("qwed-infra",), outcome_treatment="fail-closed",
+            )
+
+    def test_non_tuple_trusted_deps_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            Proof(
+                verifier="Test", verifier_version="1.0.0",
+                configuration={}, theory_scope="scope",
+                trusted_dependencies=["qwed-infra"], outcome_treatment="fail-closed",
+            )
+
+
+class TestEvidence:
+    def test_valid(self):
+        e = Evidence(payload={"test": True}, proof_ref="sha256:" + "a" * 64)
+        assert e.payload == {"test": True}
+        assert e.proof_ref == "sha256:" + "a" * 64
+
+    def test_none_proof_ref(self):
+        e = Evidence(payload={"test": True}, proof_ref=None)
+        assert e.proof_ref is None
+
+    def test_dict_serialization(self):
+        e = Evidence(payload={"test": True}, proof_ref=None)
+        d = e.to_dict()
+        assert d == {"payload": {"test": True}, "proof_ref": None}
+
+    def test_non_dict_payload_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            Evidence(payload="not-a-dict", proof_ref=None)
+
+    def test_invalid_proof_ref_format_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            Evidence(payload={"test": True}, proof_ref="not-sha256")
+
+
+class TestDecision:
+    def test_valid(self):
+        d = Decision(admission=Admission.ADMIT)
+        assert d.admission == Admission.ADMIT
+
+    def test_dict_serialization(self):
+        d = Decision(admission=Admission.DENY)
+        assert d.to_dict() == {"admission": "DENY"}
+
+    def test_non_admission_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            Decision(admission="not-admission")
+
+
+class TestVerificationContext:
+    def _context(self, admitted=True, proof_ref=None):
+        return VerificationContext(
+            interpretation=Interpretation(theory="Test theory"),
+            proof=Proof(
+                verifier="TestGuard", verifier_version="1.0.0",
+                configuration={}, theory_scope="test",
+                trusted_dependencies=("qwed-infra",),
+                outcome_treatment="fail-closed",
+            ),
+            evidence=Evidence(payload={"test": True}, proof_ref=proof_ref),
+            decision=Decision(admission=Admission.ADMIT if admitted else Admission.DENY),
+        )
+
+    def test_valid_admit(self):
+        ctx = self._context(admitted=True, proof_ref="sha256:" + "a" * 64)
+        assert ctx.decision.admission == Admission.ADMIT
+
+    def test_valid_deny_without_proof_ref(self):
+        ctx = self._context(admitted=False, proof_ref=None)
+        assert ctx.decision.admission == Admission.DENY
+
+    def test_deny_with_proof_ref_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            self._context(admitted=False, proof_ref="sha256:" + "a" * 64)
+
+    def test_dict_serialization(self):
+        ctx = self._context()
+        d = ctx.to_dict()
+        assert "interpretation" in d
+        assert "proof" in d
+        assert "evidence" in d
+        assert "decision" in d
+
+
+# =============================================================================
+# Document model tests
+# =============================================================================
+
+class TestVerificationContextDocument:
+    def _doc(self, verdict=Verdict.VERIFIED, proof_ref="sha256:" + "a" * 64):
+        return VerificationContextDocument(
+            spec_version="1.0",
+            object={"formal_statement": "test claim"},
+            context=VerificationContext(
+                interpretation=Interpretation(theory="Test"),
+                proof=Proof(
+                    verifier="Test", verifier_version="1.0",
+                    configuration={}, theory_scope="test",
+                    trusted_dependencies=(), outcome_treatment="fail-closed",
+                ),
+                evidence=Evidence(payload={"test": True}, proof_ref=proof_ref),
+                decision=Decision(admission=Admission.ADMIT),
+            ),
+            verdict=verdict,
+        )
+
+    def test_valid_verified(self):
+        doc = self._doc()
+        assert doc.verdict == Verdict.VERIFIED
+        assert doc.context.decision.admission == Admission.ADMIT
+
+    def test_valid_unverifiable(self):
+        doc = VerificationContextDocument(
+            spec_version="1.0",
+            object={"formal_statement": "test claim"},
+            context=VerificationContext(
+                interpretation=Interpretation(theory="Test"),
+                proof=Proof(
+                    verifier="Test", verifier_version="1.0",
+                    configuration={}, theory_scope="test",
+                    trusted_dependencies=(), outcome_treatment="fail-closed",
+                ),
+                evidence=Evidence(payload={"test": True}, proof_ref=None),
+                decision=Decision(admission=Admission.DENY),
+            ),
+            verdict=Verdict.UNVERIFIABLE,
+        )
+        assert doc.verdict == Verdict.UNVERIFIABLE
+
+    def test_invalid_spec_version_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            doc = self._doc()
+            VerificationContextDocument(
+                spec_version="2.0",
+                object={"formal_statement": "test"},
+                context=doc.context,
+                verdict=Verdict.VERIFIED,
+            )
+
+    def test_verified_without_proof_ref_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            self._doc(verdict=Verdict.VERIFIED, proof_ref=None)
+
+    def test_unverified_with_proof_ref_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            self._doc(verdict=Verdict.UNVERIFIABLE, proof_ref="sha256:" + "a" * 64)
+
+    def test_deny_with_verified_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            VerificationContextDocument(
+                spec_version="1.0",
+                object={"formal_statement": "test"},
+                context=VerificationContext(
+                    interpretation=Interpretation(theory="Test"),
+                    proof=Proof(
+                        verifier="Test", verifier_version="1.0",
+                        configuration={}, theory_scope="test",
+                        trusted_dependencies=(), outcome_treatment="fail-closed",
+                    ),
+                    evidence=Evidence(payload={"test": True}, proof_ref="sha256:" + "a" * 64),
+                    decision=Decision(admission=Admission.DENY),
+                ),
+                verdict=Verdict.VERIFIED,
+            )
+
+    def test_dict_serialization(self):
+        doc = self._doc()
+        d = doc.to_dict()
+        assert d["spec_version"] == "1.0"
+        assert d["object"]["formal_statement"] == "test claim"
+        assert d["verdict"] == "VERIFIED"
+
+
+# =============================================================================
+# Canonical proof functions
+# =============================================================================
+
+class TestComputeDocumentProofRef:
+    def _doc(self):
+        return {
+            "spec_version": "1.0",
+            "object": {"formal_statement": "test claim"},
+            "context": {
+                "interpretation": {"theory": "Test", "logic": "deterministic"},
+                "proof": {"verifier": "Test", "verifier_version": "1.0", "configuration": {}, "theory_scope": "test", "trusted_dependencies": [], "outcome_treatment": "fail-closed"},
+                "evidence": {"payload": {"test": True}, "proof_ref": None},
+                "decision": {"admission": "ADMIT"},
+            },
+            "verdict": "VERIFIED",
+        }
+
+    def test_computes_valid_sha256(self):
+        ref = compute_document_proof_ref(self._doc())
+        assert ref.startswith("sha256:")
+        assert len(ref) == len("sha256:") + 64
+
+    def test_excludes_proof_ref_from_bound_payload(self):
+        doc = self._doc()
+        doc["context"]["evidence"]["proof_ref"] = "sha256:" + "b" * 64
+        ref1 = compute_document_proof_ref(doc)
+        assert ref1 != "sha256:" + "b" * 64
+
+
+class TestResolveDocumentProofRef:
+    def _valid_doc(self):
+        return {
+            "spec_version": "1.0",
+            "object": {"formal_statement": "test claim"},
+            "context": {
+                "interpretation": {"theory": "Test", "logic": "deterministic"},
+                "proof": {"verifier": "Test", "verifier_version": "1.0", "configuration": {}, "theory_scope": "test", "trusted_dependencies": [], "outcome_treatment": "fail-closed"},
+                "evidence": {"payload": {"test": True}, "proof_ref": None},
+                "decision": {"admission": "ADMIT"},
+            },
+            "verdict": "VERIFIED",
+        }
+
+    def test_valid_doc_resolves(self):
+        doc = self._valid_doc()
+        doc["context"]["evidence"]["proof_ref"] = compute_document_proof_ref(doc)
+        assert resolve_document_proof_ref(doc) is True
+
+    def test_wrong_proof_ref_rejected(self):
+        doc = self._valid_doc()
+        doc["context"]["evidence"]["proof_ref"] = "sha256:" + "c" * 64
+        assert resolve_document_proof_ref(doc) is False
+
+    def test_non_verified_rejected(self):
+        doc = self._valid_doc()
+        doc["verdict"] = "BLOCKED"
+        assert resolve_document_proof_ref(doc) is False
+
+
+class TestIsValidDocument:
+    def test_valid_verified(self):
+        # Build a document and resolve its actual proof_ref
+        doc = self._full_doc(verdict="VERIFIED", admission="ADMIT", proof_ref=None)
+        doc["context"]["evidence"]["proof_ref"] = compute_document_proof_ref(doc)
+        assert is_valid_document(doc) is True
+
+    def test_valid_unverifiable(self):
+        doc = self._full_doc(verdict="UNVERIFIABLE", admission="DENY", proof_ref=None)
+        assert is_valid_document(doc) is True
+
+    def test_valid_blocked(self):
+        doc = self._full_doc(verdict="BLOCKED", admission="DENY", proof_ref=None)
+        assert is_valid_document(doc) is True
+
+    def test_invalid_missing_object_rejected(self):
+        doc = {"spec_version": "1.0", "verdict": "VERIFIED"}
+        assert is_valid_document(doc) is False
+
+    def test_invalid_missing_context_rejected(self):
+        doc = {"spec_version": "1.0", "object": {"formal_statement": "test"}, "verdict": "VERIFIED"}
+        assert is_valid_document(doc) is False
+
+    def test_invalid_missing_evidence_rejected(self):
+        doc = {
+            "spec_version": "1.0",
+            "object": {"formal_statement": "test"},
+            "context": {
+                "interpretation": {},
+                "proof": {},
+                "decision": {"admission": "ADMIT"},
+            },
+            "verdict": "VERIFIED",
+        }
+        assert is_valid_document(doc) is False
+
+    def test_invalid_verified_without_proof_ref_rejected(self):
+        doc = self._full_doc(verdict="VERIFIED", admission="ADMIT", proof_ref=None)
+        assert is_valid_document(doc) is False
+
+    def test_invalid_non_verified_with_proof_ref_rejected(self):
+        doc = self._full_doc(verdict="BLOCKED", admission="DENY", proof_ref="sha256:" + "a" * 64)
+        assert is_valid_document(doc) is False
+
+    def test_invalid_spec_version_rejected(self):
+        doc = self._full_doc()
+        doc["spec_version"] = "2.0"
+        assert is_valid_document(doc) is False
+
+    def test_invalid_verdict_rejected(self):
+        doc = self._full_doc()
+        doc["verdict"] = "INVALID"
+        assert is_valid_document(doc) is False
+
+    def test_non_dict_rejected(self):
+        assert is_valid_document("not-a-dict") is False
+
+    def _full_doc(self, verdict="VERIFIED", admission="ADMIT", proof_ref="sha256:" + "a" * 64):
+        return {
+            "spec_version": "1.0",
+            "object": {"formal_statement": "test claim"},
+            "context": {
+                "interpretation": {"theory": "Test", "logic": "deterministic"},
+                "proof": {"verifier": "Test", "verifier_version": "1.0", "configuration": {}, "theory_scope": "test", "trusted_dependencies": [], "outcome_treatment": "fail-closed"},
+                "evidence": {"payload": {"test": True}, "proof_ref": proof_ref},
+                "decision": {"admission": admission},
+            },
+            "verdict": verdict,
+        }
+
+    def test_invalid_missing_object_rejected(self):
+        doc = {"spec_version": "1.0", "verdict": "VERIFIED"}
+        assert is_valid_document(doc) is False
+
+    def test_invalid_missing_context_rejected(self):
+        doc = {"spec_version": "1.0", "object": {"formal_statement": "test"}, "verdict": "VERIFIED"}
+        assert is_valid_document(doc) is False
+
+    def test_invalid_missing_evidence_rejected(self):
+        doc = {
+            "spec_version": "1.0",
+            "object": {"formal_statement": "test"},
+            "context": {
+                "interpretation": {},
+                "proof": {},
+                "decision": {"admission": "ADMIT"},
+            },
+            "verdict": "VERIFIED",
+        }
+        assert is_valid_document(doc) is False
+
+    def test_invalid_verified_without_proof_ref_rejected(self):
+        doc = self._full_doc(verdict="VERIFIED", admission="ADMIT", proof_ref=None)
+        assert is_valid_document(doc) is False
+
+    def test_invalid_non_verified_with_proof_ref_rejected(self):
+        doc = self._full_doc(verdict="BLOCKED", admission="DENY", proof_ref="sha256:" + "a" * 64)
+        assert is_valid_document(doc) is False
+
+    def test_invalid_spec_version_rejected(self):
+        doc = self._full_doc()
+        doc["spec_version"] = "2.0"
+        assert is_valid_document(doc) is False
+
+    def test_invalid_verdict_rejected(self):
+        doc = self._full_doc()
+        doc["verdict"] = "INVALID"
+        assert is_valid_document(doc) is False
+
+    def test_non_dict_rejected(self):
+        assert is_valid_document("not-a-dict") is False
+
+    def _full_doc(self, verdict="VERIFIED", admission="ADMIT", proof_ref="sha256:" + "a" * 64):
+        return {
+            "spec_version": "1.0",
+            "object": {"formal_statement": "test claim"},
+            "context": {
+                "interpretation": {"theory": "Test", "logic": "deterministic"},
+                "proof": {"verifier": "Test", "verifier_version": "1.0", "configuration": {}, "theory_scope": "test", "trusted_dependencies": [], "outcome_treatment": "fail-closed"},
+                "evidence": {"payload": {"test": True}, "proof_ref": proof_ref},
+                "decision": {"admission": admission},
+            },
+            "verdict": verdict,
+        }
+
+
+# =============================================================================
+# Canonical JSON tests (RFC 8785)
+# =============================================================================
+
+class TestCanonicalJson:
+    def test_simple_object(self):
+        result = _canonical_json({"b": 1, "a": 2})
+        assert '"a":2.0' in result
+        assert result.index('"a"') < result.index('"b"')
+
+    def test_nested_object(self):
+        result = _canonical_json({"outer": {"inner": [1, 2]}})
+        assert '"outer":{"inner":[1.0,2.0]}' in result
+
+    def test_null(self):
+        assert _canonical_json(None) == "null"
+
+    def test_bool(self):
+        assert _canonical_json(True) == "true"
+        assert _canonical_json(False) == "false"
+
+    def test_int(self):
+        # RFC 8785: int→float path, serialize via IEEE-754 float
+        assert _canonical_json(42) == "42.0"
+        assert _canonical_json(0) == "0"  # coefficient=0 special case
+        assert _canonical_json(-42) == "-42.0"
+
+    def test_float(self):
+        assert _canonical_json(4.5) == "4.5"
+        # zero serializes as plain "0" in RFC 8785
+        assert _canonical_json(0.0) == "0"
+
+    def test_string(self):
+        assert _canonical_json("test") == '"test"'
+        assert _canonical_json("café") == '"café"'
+
+    def test_list(self):
+        result = _canonical_json([3, 1, 2])
+        assert result == "[3.0,1.0,2.0]"
+
+    def test_tuple_converts_to_list(self):
+        result = _canonical_json((1, 2))
+        assert result == "[1.0,2.0]"
+
+    def test_large_int_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            _canonical_json(2**53 + 1)
+
+    def test_nan_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            _canonical_json(float("nan"))
+
+    def test_inf_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            _canonical_json(float("inf"))
+
+    def test_unsupported_type_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            _canonical_json(object())
+
+    def test_unordered_dict_keys(self):
+        result = _canonical_json({"zebra": 1, "apple": 2})
+        assert result.index('"apple"') < result.index('"zebra"')
+
+    def test_nested_list(self):
+        result = _canonical_json([[1, 2], [3, 4]])
+        assert result == "[[1.0,2.0],[3.0,4.0]]"
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def _canonical_json(value):
+    from qwed_infra.verification_context import _canonical_json
+    return _canonical_json(value)
+
+
+# =============================================================================
+# Freeze-thaw tests
+# =============================================================================
+
+class TestFreezeThaw:
+    def test_freeze_mapping(self):
+        f = _freeze_value({"a": 1, "b": [2, 3]})
+        assert f["a"] == 1
+
+    def test_freeze_tuple(self):
+        f = _freeze_value([1, 2, (3, 4)])
+        assert f == (1, 2, (3, 4))
+
+    def test_freeze_scalar(self):
+        assert _freeze_value("test") == "test"
+
+    def test_thaw_mappingproxy(self):
+        f = _freeze_value({"a": 1})
+        t = _thaw_value(f)
+        assert t == {"a": 1}
+
+    def test_thaw_dict(self):
+        t = _thaw_value({"a": 1})
+        assert t == {"a": 1}
+
+    def test_thaw_tuple(self):
+        t = _thaw_value((1, 2, (3, 4)))
+        assert t == [1, 2, [3, 4]]
+
+    def test_thaw_scalar(self):
+        assert _thaw_value("test") == "test"
+
+
+def _freeze_value(value):
+    from qwed_infra.verification_context import _freeze_value
+    return _freeze_value(value)
+
+def _thaw_value(value):
+    from qwed_infra.verification_context import _thaw_value
+    return _thaw_value(value)
+
+
+# =============================================================================
+# Numeric formatting tests
+# =============================================================================
+
+class TestEsNumberFormatting:
+    def test_positive_integer(self):
+        # RFC 8785: int→float path, 42.0 → "42.0"
+        assert _es_number_to_string(42.0) == "42.0"
+
+    def test_negative_integer(self):
+        assert _es_number_to_string(-42.0) == "-42.0"
+
+    def test_zero(self):
+        assert _es_number_to_string(0.0) == "0"
+
+    def test_decimal(self):
+        assert _es_number_to_string(4.5) == "4.5"
+
+    def test_exponent_positive(self):
+        assert _es_number_to_string(450.0) == "450.0"
+
+    def test_exponent_negative(self):
+        assert _es_number_to_string(0.045) == "0.045"
+
+    def test_nan_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            _es_number_to_string(float("nan"))
+
+    def test_infinity_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            _es_number_to_string(float("inf"))
+
+
+def _es_number_to_string(value):
+    from qwed_infra.verification_context import _es_number_to_string
+    return _es_number_to_string(value)
+
+
+# =============================================================================
+# Surrogate validation tests
+# =============================================================================
+
+class TestRejectUnpairedSurrogates:
+    def test_valid_string(self):
+        _reject_unpaired_surrogates("hello world")
+
+    def test_valid_unicode(self):
+        _reject_unpaired_surrogates("café 東京")
+
+    def test_valid_surrogate_pair(self):
+        _reject_unpaired_surrogates("🚀 rocket")
+
+
+def _reject_unpaired_surrogates(value):
+    from qwed_infra.verification_context import _reject_unpaired_surrogates
+    return _reject_unpaired_surrogates(value)
+
+
+# =============================================================================
+# Bridge tests
+# =============================================================================
+
+class TestBridge:
+    def _verified_result(self):
+        return InfraDiagnosticResult.verified(
+            agent_message="test verified",
+            developer_fields={"audit_trace": {"rule": "test.deny"}, "data": 1},
+            evidence={"rule": "test.deny"},
+        )
+
+    def test_verified_with_attestation(self):
+        result = self._verified_result()
+        vc = verification_context_from_diagnostic_result(
+            result,
+            formal_statement="test claim",
+            verifier="IamGuard",
+            attestation_token="fake-jwt",
+        )
+        assert vc.verdict == Verdict.VERIFIED
+        assert vc.context.decision.admission == Admission.ADMIT
+        # Bridge now computes document-bound proof_ref, NOT diagnostic proof_ref
+        assert vc.context.evidence.proof_ref.startswith("sha256:")
+        assert len(vc.context.evidence.proof_ref) == 71  # sha256: + 64 hex chars
+        doc_dict = vc.to_dict()
+        # The document's own proof_ref must resolve against itself
+        assert resolve_document_proof_ref(doc_dict) is True
+
+    def test_verified_without_attestation(self):
+        result = self._verified_result()
+        vc = verification_context_from_diagnostic_result(
+            result,
+            formal_statement="test claim",
+            verifier="IamGuard",
+        )
+        assert vc.verdict == Verdict.UNVERIFIABLE
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+
+    def test_unverifiable(self):
+        result = InfraDiagnosticResult.unverifiable(
+            agent_message="unverified test",
+            developer_fields={"reason": "unknown"},
+        )
+        vc = verification_context_from_diagnostic_result(
+            result,
+            formal_statement="test claim",
+            verifier="IamGuard",
+        )
+        assert vc.verdict == Verdict.UNVERIFIABLE
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+
+    def test_blocked(self):
+        result = InfraDiagnosticResult.blocked(
+            agent_message="blocked test",
+            developer_fields={"reason": "violation"},
+        )
+        vc = verification_context_from_diagnostic_result(
+            result,
+            formal_statement="test claim",
+            verifier="IamGuard",
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+
+    def test_empty_formal_statement_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            verification_context_from_diagnostic_result(
+                self._verified_result(),
+                formal_statement="",
+                verifier="IamGuard",
+            )
+
+    def test_empty_verifier_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            verification_context_from_diagnostic_result(
+                self._verified_result(),
+                formal_statement="test claim",
+                verifier="",
+            )
+
+    def test_evidence_preserves_developer_fields(self):
+        result = InfraDiagnosticResult.verified(
+            agent_message="test",
+            developer_fields={"test": 1, "audit_trace": {"rule": "x"}},
+            evidence={"test": 1},
+        )
+        vc = verification_context_from_diagnostic_result(
+            result,
+            formal_statement="test",
+            verifier="TestGuard",
+            attestation_token="fake-jwt",
+        )
+        assert "developer_fields" in vc.context.evidence.payload
+        assert "audit_trace" in vc.context.evidence.payload["developer_fields"]
+
+
+class TestBridgeEdgeCases:
+    def test_malformed_developer_fields_via_bypass(self):
+        # Post-init rejects non-dict; bypass constructor via object.__new__
+        result = object.__new__(InfraDiagnosticResult)
+        object.__setattr__(result, 'status', InfraDiagnosticStatus.UNVERIFIABLE)
+        object.__setattr__(result, 'agent_message', "test")
+        object.__setattr__(result, 'developer_fields', "not-a-dict")
+        object.__setattr__(result, 'proof_ref', None)
+
+        vc = verification_context_from_diagnostic_result(
+            result,
+            formal_statement="test claim",
+            verifier="IamGuard",
+        )
+        assert vc.verdict == Verdict.BLOCKED
+
+    def test_evidence_excludes_proof_ref_from_payload(self):
+        result = InfraDiagnosticResult.verified(
+            agent_message="test",
+            developer_fields={"test": 1, "audit_trace": {"rule": "x"}},
+            evidence={"test": 1},
+        )
+        vc = verification_context_from_diagnostic_result(
+            result,
+            formal_statement="test",
+            verifier="TestGuard",
+            attestation_token="fake-jwt",
+        )
+        ref_in_doc = vc.context.evidence.proof_ref
+        assert ref_in_doc is not None
+        assert ref_in_doc.startswith("sha256:")
+        assert len(ref_in_doc) == 71  # sha256: + 64 hex chars
+        # proof_ref in evidence payload should be None (excluded before hashing)
+        assert vc.context.evidence.payload.get("proof_ref") is None

--- a/tests/test_verification_context.py
+++ b/tests/test_verification_context.py
@@ -425,6 +425,49 @@ class TestIsValidDocument:
         doc["context"]["evidence"]["payload"] = {"bad": object()}
         assert is_valid_document(doc) is False
 
+    def test_unserializable_object_rejected(self):
+        doc = self._full_doc(verdict="BLOCKED", admission="DENY", proof_ref=None)
+        doc["object"]["formal_statement"] = {"bad": object()}
+        assert is_valid_document(doc) is False
+
+    def test_unserializable_formalization_rejected(self):
+        doc = self._full_doc(verdict="BLOCKED", admission="DENY", proof_ref=None)
+        doc["object"]["formalization"] = {"source_query": object(), "translator": "Test"}
+        assert is_valid_document(doc) is False
+
+
+class TestConstructorRejectsUnsupportedLeaves:
+    def test_proof_rejects_set(self):
+        with pytest.raises(VerificationContextValidationError):
+            Proof(
+                verifier="Test", verifier_version="1.0",
+                configuration={"mode": {"a", "b"}},
+                theory_scope="test", trusted_dependencies=(),
+                outcome_treatment="fail-closed",
+            )
+
+    def test_evidence_rejects_bytearray(self):
+        with pytest.raises(VerificationContextValidationError):
+            Evidence(payload={"data": bytearray(b"x")}, proof_ref=None)
+
+    def test_document_rejects_object_leaf(self):
+        with pytest.raises(VerificationContextValidationError):
+            VerificationContextDocument(
+                spec_version="1.0",
+                object={"formal_statement": "test", "extra": object()},
+                context=VerificationContext(
+                    interpretation=Interpretation(theory="Test"),
+                    proof=Proof(
+                        verifier="Test", verifier_version="1.0",
+                        configuration={}, theory_scope="test",
+                        trusted_dependencies=(), outcome_treatment="fail-closed",
+                    ),
+                    evidence=Evidence(payload={"test": True}, proof_ref=None),
+                    decision=Decision(admission=Admission.DENY),
+                ),
+                verdict=Verdict.BLOCKED,
+            )
+
 
 # =============================================================================
 # Canonical JSON tests (RFC 8785)

--- a/tests/test_verification_context.py
+++ b/tests/test_verification_context.py
@@ -224,8 +224,8 @@ class TestVerificationContextDocument:
         assert doc.verdict == Verdict.UNVERIFIABLE
 
     def test_invalid_spec_version_rejected(self):
+        doc = self._doc()
         with pytest.raises(VerificationContextValidationError):
-            doc = self._doc()
             VerificationContextDocument(
                 spec_version="2.0",
                 object={"formal_statement": "test"},
@@ -460,12 +460,14 @@ class TestIsValidDocument:
 class TestCanonicalJson:
     def test_simple_object(self):
         result = _canonical_json({"b": 1, "a": 2})
-        assert '"a":2.0' in result
+        # Integer-valued floats serialize as integers per ECMAScript
+        assert '"a":2' in result
         assert result.index('"a"') < result.index('"b"')
 
     def test_nested_object(self):
         result = _canonical_json({"outer": {"inner": [1, 2]}})
-        assert '"outer":{"inner":[1.0,2.0]}' in result
+        # Integer-valued floats serialize as integers per ECMAScript
+        assert '"outer":{"inner":[1,2]}' in result
 
     def test_null(self):
         assert _canonical_json(None) == "null"
@@ -475,10 +477,10 @@ class TestCanonicalJson:
         assert _canonical_json(False) == "false"
 
     def test_int(self):
-        # RFC 8785: int→float path, serialize via IEEE-754 float
-        assert _canonical_json(42) == "42.0"
-        assert _canonical_json(0) == "0"  # coefficient=0 special case
-        assert _canonical_json(-42) == "-42.0"
+        # ECMAScript Number::toString: integer-valued float -> integer-form digits
+        assert _canonical_json(42) == "42"
+        assert _canonical_json(0) == "0"
+        assert _canonical_json(-42) == "-42"
 
     def test_float(self):
         assert _canonical_json(4.5) == "4.5"
@@ -491,11 +493,12 @@ class TestCanonicalJson:
 
     def test_list(self):
         result = _canonical_json([3, 1, 2])
-        assert result == "[3.0,1.0,2.0]"
+        # ECMAScript: integer-valued floats serialize as integers
+        assert result == "[3,1,2]"
 
     def test_tuple_converts_to_list(self):
         result = _canonical_json((1, 2))
-        assert result == "[1.0,2.0]"
+        assert result == "[1,2]"
 
     def test_large_int_rejected(self):
         with pytest.raises(VerificationContextValidationError):
@@ -519,7 +522,7 @@ class TestCanonicalJson:
 
     def test_nested_list(self):
         result = _canonical_json([[1, 2], [3, 4]])
-        assert result == "[[1.0,2.0],[3.0,4.0]]"
+        assert result == "[[1,2],[3,4]]"
 
 
 # =============================================================================
@@ -579,11 +582,12 @@ def _thaw_value(value):
 
 class TestEsNumberFormatting:
     def test_positive_integer(self):
-        # RFC 8785: int→float path, 42.0 → "42.0"
-        assert _es_number_to_string(42.0) == "42.0"
+        # ECMAScript Number::toString: integer-valued float -> integer-form digits
+        assert _es_number_to_string(42.0) == "42"
 
     def test_negative_integer(self):
-        assert _es_number_to_string(-42.0) == "-42.0"
+        # ECMAScript Number::toString: integer-valued float -> integer-form digits
+        assert _es_number_to_string(-42.0) == "-42"
 
     def test_zero(self):
         assert _es_number_to_string(0.0) == "0"
@@ -592,7 +596,8 @@ class TestEsNumberFormatting:
         assert _es_number_to_string(4.5) == "4.5"
 
     def test_exponent_positive(self):
-        assert _es_number_to_string(450.0) == "450.0"
+        # ECMAScript Number::toString: integer-valued float -> integer-form digits
+        assert _es_number_to_string(450.0) == "450"
 
     def test_exponent_negative(self):
         assert _es_number_to_string(0.045) == "0.045"
@@ -706,6 +711,24 @@ class TestBridge:
                 formal_statement="",
                 verifier="IamGuard",
             )
+
+    def test_malformed_status_blocked_fail_closed(self):
+        # Malformed string status ("VERIFIED" as string) must produce BLOCKED
+        # as fail-closed protection (no AttributeError through the bridge).
+        result = object.__new__(InfraDiagnosticResult)
+        object.__setattr__(result, 'status', "VERIFIED")  # string, not enum
+        object.__setattr__(result, 'agent_message', "test")
+        object.__setattr__(result, 'developer_fields', {"test": 1})
+        object.__setattr__(result, 'proof_ref', "sha256:" + "a" * 64)
+
+        vc = verification_context_from_diagnostic_result(
+            result,
+            formal_statement="test claim",
+            verifier="IamGuard",
+        )
+        # Malformed status demotes to BLOCKED, not ADMIT
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
 
     def test_empty_verifier_rejected(self):
         with pytest.raises(VerificationContextValidationError):

--- a/tests/test_verification_context.py
+++ b/tests/test_verification_context.py
@@ -217,6 +217,16 @@ class TestVerificationContextDocument:
         assert doc.verdict == Verdict.VERIFIED
         assert doc.context.decision.admission == Admission.ADMIT
 
+    def test_non_formalization_value_rejected(self):
+        with pytest.raises(VerificationContextValidationError):
+            VerificationContextDocument(
+                spec_version="1.0",
+                object={"formal_statement": "test claim"},
+                context=self._doc().context,
+                verdict=Verdict.BLOCKED,
+                formalization="not-a-formalization",
+            )
+
     def test_valid_unverifiable(self):
         doc = VerificationContextDocument(
             spec_version="1.0",
@@ -436,6 +446,11 @@ class TestIsValidDocument:
     def test_unserializable_object_rejected(self):
         doc = self._full_doc(verdict="BLOCKED", admission="DENY", proof_ref=None)
         doc["object"]["formal_statement"] = {"bad": object()}
+        assert is_valid_document(doc) is False
+
+    def test_missing_proof_ref_key_rejected(self):
+        doc = self._full_doc(verdict="BLOCKED", admission="DENY", proof_ref=None)
+        del doc["context"]["evidence"]["proof_ref"]
         assert is_valid_document(doc) is False
 
     def test_unserializable_formalization_rejected(self):

--- a/tests/test_verification_context.py
+++ b/tests/test_verification_context.py
@@ -195,20 +195,43 @@ class TestVerificationContext:
 # =============================================================================
 
 class TestVerificationContextDocument:
-    def _doc(self, verdict=Verdict.VERIFIED, proof_ref="sha256:" + "a" * 64):
+    def _build(self, verdict=Verdict.VERIFIED, formal_statement="test claim"):
+        interpretation = Interpretation(theory="Test")
+        proof = Proof(
+            verifier="Test", verifier_version="1.0",
+            configuration={}, theory_scope="test",
+            trusted_dependencies=(), outcome_treatment="fail-closed",
+        )
+        decision = Decision(
+            admission=Admission.ADMIT if verdict is Verdict.VERIFIED else Admission.DENY
+        )
+        context = VerificationContext(
+            interpretation=interpretation,
+            proof=proof,
+            evidence=Evidence(payload={"test": True}, proof_ref=None),
+            decision=decision,
+        )
+        return formal_statement, context
+
+    def _doc(self, verdict=Verdict.VERIFIED, formal_statement="test claim"):
+        formal_statement, context = self._build(verdict, formal_statement)
+        if verdict is Verdict.VERIFIED:
+            ref = compute_document_proof_ref({
+                "spec_version": "1.0",
+                "object": {"formal_statement": formal_statement},
+                "context": context.to_dict(),
+                "verdict": "VERIFIED",
+            })
+            context = VerificationContext(
+                interpretation=context.interpretation,
+                proof=context.proof,
+                evidence=Evidence(payload={"test": True}, proof_ref=ref),
+                decision=context.decision,
+            )
         return VerificationContextDocument(
             spec_version="1.0",
-            object={"formal_statement": "test claim"},
-            context=VerificationContext(
-                interpretation=Interpretation(theory="Test"),
-                proof=Proof(
-                    verifier="Test", verifier_version="1.0",
-                    configuration={}, theory_scope="test",
-                    trusted_dependencies=(), outcome_treatment="fail-closed",
-                ),
-                evidence=Evidence(payload={"test": True}, proof_ref=proof_ref),
-                decision=Decision(admission=Admission.ADMIT),
-            ),
+            object={"formal_statement": formal_statement},
+            context=context,
             verdict=verdict,
         )
 
@@ -217,12 +240,32 @@ class TestVerificationContextDocument:
         assert doc.verdict == Verdict.VERIFIED
         assert doc.context.decision.admission == Admission.ADMIT
 
-    def test_non_formalization_value_rejected(self):
+    def test_unbound_proof_ref_rejected(self):
+        context = VerificationContext(
+            interpretation=Interpretation(theory="Test"),
+            proof=Proof(
+                verifier="Test", verifier_version="1.0",
+                configuration={}, theory_scope="test",
+                trusted_dependencies=(), outcome_treatment="fail-closed",
+            ),
+            evidence=Evidence(payload={"test": True}, proof_ref="sha256:" + "a" * 64),
+            decision=Decision(admission=Admission.ADMIT),
+        )
         with pytest.raises(VerificationContextValidationError):
             VerificationContextDocument(
                 spec_version="1.0",
                 object={"formal_statement": "test claim"},
-                context=self._doc().context,
+                context=context,
+                verdict=Verdict.VERIFIED,
+            )
+
+    def test_non_formalization_value_rejected(self):
+        context = self._build(Verdict.BLOCKED)[1]
+        with pytest.raises(VerificationContextValidationError):
+            VerificationContextDocument(
+                spec_version="1.0",
+                object={"formal_statement": "test claim"},
+                context=context,
                 verdict=Verdict.BLOCKED,
                 formalization="not-a-formalization",
             )
@@ -256,13 +299,20 @@ class TestVerificationContextDocument:
             )
 
     def test_verified_without_proof_ref_rejected(self):
+        formal_statement, context = self._build(Verdict.VERIFIED)
+        context = VerificationContext(
+            interpretation=context.interpretation,
+            proof=context.proof,
+            evidence=Evidence(payload={"test": True}, proof_ref=None),
+            decision=context.decision,
+        )
         with pytest.raises(VerificationContextValidationError):
-            self._doc(verdict=Verdict.VERIFIED, proof_ref=None)
-
-    def test_unverified_with_proof_ref_rejected(self):
-        proof_ref = "sha256:" + "a" * 64
-        with pytest.raises(VerificationContextValidationError):
-            self._doc(verdict=Verdict.UNVERIFIABLE, proof_ref=proof_ref)
+            VerificationContextDocument(
+                spec_version="1.0",
+                object={"formal_statement": formal_statement},
+                context=context,
+                verdict=Verdict.VERIFIED,
+            )
 
     def test_admit_with_unverified_verdict_rejected(self):
         # UNVERIFIABLE verdict requires DENY admission; ADMIT with non-VERIFIED
@@ -393,6 +443,13 @@ class TestIsValidDocument:
         doc = self._full_doc(verdict="VERIFIED", admission="ADMIT", proof_ref=None)
         assert is_valid_document(doc) is False
 
+    def test_verified_surrogate_does_not_raise(self):
+        # A surrogate-bearing VERIFIED document must fail closed (False),
+        # not escape as UnicodeEncodeError during proof_ref hashing.
+        doc = self._full_doc(verdict="VERIFIED", admission="ADMIT", proof_ref="sha256:" + "a" * 64)
+        doc["context"]["interpretation"]["theory"] = "\ud800\udc00"
+        assert is_valid_document(doc) is False
+
     def test_invalid_non_verified_with_proof_ref_rejected(self):
         doc = self._full_doc(verdict="BLOCKED", admission="DENY", proof_ref="sha256:" + "a" * 64)
         assert is_valid_document(doc) is False
@@ -461,6 +518,13 @@ class TestIsValidDocument:
     def test_surrogate_in_theory_rejected(self):
         doc = self._full_doc(verdict="BLOCKED", admission="DENY", proof_ref=None)
         doc["context"]["interpretation"]["theory"] = "bad\ud800"
+        assert is_valid_document(doc) is False
+
+    def test_paired_surrogate_in_theory_rejected(self):
+        # Adjacent high+low surrogate code units cannot be UTF-8 encoded for
+        # hashing; they must be rejected fail-closed, not raise UnicodeEncodeError.
+        doc = self._full_doc(verdict="BLOCKED", admission="DENY", proof_ref=None)
+        doc["context"]["interpretation"]["theory"] = "\ud800\udc00"
         assert is_valid_document(doc) is False
 
     def test_surrogate_in_proof_verifier_rejected(self):

--- a/tests/test_verification_context.py
+++ b/tests/test_verification_context.py
@@ -582,11 +582,9 @@ def _thaw_value(value):
 
 class TestEsNumberFormatting:
     def test_positive_integer(self):
-        # ECMAScript Number::toString: integer-valued float -> integer-form digits
         assert _es_number_to_string(42.0) == "42"
 
     def test_negative_integer(self):
-        # ECMAScript Number::toString: integer-valued float -> integer-form digits
         assert _es_number_to_string(-42.0) == "-42"
 
     def test_zero(self):
@@ -595,12 +593,21 @@ class TestEsNumberFormatting:
     def test_decimal(self):
         assert _es_number_to_string(4.5) == "4.5"
 
-    def test_exponent_positive(self):
-        # ECMAScript Number::toString: integer-valued float -> integer-form digits
-        assert _es_number_to_string(450.0) == "450"
+    def test_large_integer_float(self):
+        # ECMAScript: 1e16 is within fixed-point range -> "10000000000000000"
+        assert _es_number_to_string(1e16) == "10000000000000000"
 
-    def test_exponent_negative(self):
-        assert _es_number_to_string(0.045) == "0.045"
+    def test_exponential_threshold_upper(self):
+        # ECMAScript: >= 1e21 uses exponential -> "1e+21"
+        assert _es_number_to_string(1e21) == "1e+21"
+
+    def test_exponential_threshold_lower(self):
+        # ECMAScript: < 1e-6 uses exponential -> "1e-7"
+        assert _es_number_to_string(1e-7) == "1e-7"
+
+    def test_within_threshold_fixed(self):
+        # ECMAScript: 1e-5 is >= 1e-6, uses fixed -> "0.00001"
+        assert _es_number_to_string(1e-5) == "0.00001"
 
     def test_nan_rejected(self):
         with pytest.raises(VerificationContextValidationError):
@@ -705,9 +712,10 @@ class TestBridge:
         assert vc.context.evidence.proof_ref is None
 
     def test_empty_formal_statement_rejected(self):
+        result = self._verified_result()
         with pytest.raises(VerificationContextValidationError):
             verification_context_from_diagnostic_result(
-                self._verified_result(),
+                result,
                 formal_statement="",
                 verifier="IamGuard",
             )
@@ -731,9 +739,10 @@ class TestBridge:
         assert vc.context.decision.admission == Admission.DENY
 
     def test_empty_verifier_rejected(self):
+        result = self._verified_result()
         with pytest.raises(VerificationContextValidationError):
             verification_context_from_diagnostic_result(
-                self._verified_result(),
+                result,
                 formal_statement="test claim",
                 verifier="",
             )

--- a/tests/test_verification_context.py
+++ b/tests/test_verification_context.py
@@ -435,6 +435,21 @@ class TestIsValidDocument:
         doc["object"]["formalization"] = {"source_query": object(), "translator": "Test"}
         assert is_valid_document(doc) is False
 
+    def test_surrogate_in_theory_rejected(self):
+        doc = self._full_doc(verdict="BLOCKED", admission="DENY", proof_ref=None)
+        doc["context"]["interpretation"]["theory"] = "bad\ud800"
+        assert is_valid_document(doc) is False
+
+    def test_surrogate_in_proof_verifier_rejected(self):
+        doc = self._full_doc(verdict="BLOCKED", admission="DENY", proof_ref=None)
+        doc["context"]["proof"]["verifier"] = "bad\ud800"
+        assert is_valid_document(doc) is False
+
+    def test_surrogate_in_trusted_dependency_rejected(self):
+        doc = self._full_doc(verdict="BLOCKED", admission="DENY", proof_ref=None)
+        doc["context"]["proof"]["trusted_dependencies"] = ["bad\ud800"]
+        assert is_valid_document(doc) is False
+
 
 class TestConstructorRejectsUnsupportedLeaves:
     def test_proof_rejects_set(self):

--- a/tests/test_verification_context.py
+++ b/tests/test_verification_context.py
@@ -451,20 +451,21 @@ class TestConstructorRejectsUnsupportedLeaves:
             Evidence(payload={"data": bytearray(b"x")}, proof_ref=None)
 
     def test_document_rejects_object_leaf(self):
+        context = VerificationContext(
+            interpretation=Interpretation(theory="Test"),
+            proof=Proof(
+                verifier="Test", verifier_version="1.0",
+                configuration={}, theory_scope="test",
+                trusted_dependencies=(), outcome_treatment="fail-closed",
+            ),
+            evidence=Evidence(payload={"test": True}, proof_ref=None),
+            decision=Decision(admission=Admission.DENY),
+        )
         with pytest.raises(VerificationContextValidationError):
             VerificationContextDocument(
                 spec_version="1.0",
                 object={"formal_statement": "test", "extra": object()},
-                context=VerificationContext(
-                    interpretation=Interpretation(theory="Test"),
-                    proof=Proof(
-                        verifier="Test", verifier_version="1.0",
-                        configuration={}, theory_scope="test",
-                        trusted_dependencies=(), outcome_treatment="fail-closed",
-                    ),
-                    evidence=Evidence(payload={"test": True}, proof_ref=None),
-                    decision=Decision(admission=Admission.DENY),
-                ),
+                context=context,
                 verdict=Verdict.BLOCKED,
             )
 
@@ -783,6 +784,26 @@ class TestBridge:
         )
         assert "developer_fields" in vc.context.evidence.payload
         assert "audit_trace" in vc.context.evidence.payload["developer_fields"]
+
+    def test_demoted_verified_preserves_diagnostic_proof_ref(self):
+        # VERIFIED without attestation → demoted to UNVERIFIABLE, but the
+        # original diagnostic proof_ref must be preserved in the evidence trail.
+        result = InfraDiagnosticResult.verified(
+            agent_message="verified diagnostic",
+            developer_fields={"test": 1, "audit_trace": {"rule": "x"}},
+            evidence={"test": 1},
+        )
+        vc = verification_context_from_diagnostic_result(
+            result,
+            formal_statement="test",
+            verifier="IamGuard",
+        )
+        assert vc.verdict == Verdict.UNVERIFIABLE
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        # audit trail preserved: diagnostic_proof_ref in payload
+        assert "diagnostic_proof_ref" in vc.context.evidence.payload
+        assert vc.context.evidence.payload["diagnostic_proof_ref"] == result.proof_ref
 
 
 class TestBridgeEdgeCases:

--- a/tests/test_verification_context.py
+++ b/tests/test_verification_context.py
@@ -121,12 +121,14 @@ class TestEvidence:
         assert d == {"payload": {"test": True}, "proof_ref": None}
 
     def test_non_dict_payload_rejected(self):
+        bad_payload = "not-a-dict"
         with pytest.raises(VerificationContextValidationError):
-            Evidence(payload="not-a-dict", proof_ref=None)
+            Evidence(payload=bad_payload, proof_ref=None)
 
     def test_invalid_proof_ref_format_rejected(self):
+        bad_ref = "not-sha256"
         with pytest.raises(VerificationContextValidationError):
-            Evidence(payload={"test": True}, proof_ref="not-sha256")
+            Evidence(payload={"test": True}, proof_ref=bad_ref)
 
 
 class TestDecision:
@@ -139,8 +141,9 @@ class TestDecision:
         assert d.to_dict() == {"admission": "DENY"}
 
     def test_non_admission_rejected(self):
+        bad_admission = "not-admission"
         with pytest.raises(VerificationContextValidationError):
-            Decision(admission="not-admission")
+            Decision(admission=bad_admission)
 
 
 class TestVerificationContext:

--- a/tests/test_verification_context.py
+++ b/tests/test_verification_context.py
@@ -501,20 +501,24 @@ class TestCanonicalJson:
         assert result == "[1,2]"
 
     def test_large_int_rejected(self):
+        val = 2**53 + 1
         with pytest.raises(VerificationContextValidationError):
-            _canonical_json(2**53 + 1)
+            _canonical_json(val)
 
     def test_nan_rejected(self):
+        val = float("nan")
         with pytest.raises(VerificationContextValidationError):
-            _canonical_json(float("nan"))
+            _canonical_json(val)
 
     def test_inf_rejected(self):
+        val = float("inf")
         with pytest.raises(VerificationContextValidationError):
-            _canonical_json(float("inf"))
+            _canonical_json(val)
 
     def test_unsupported_type_rejected(self):
+        val = object()
         with pytest.raises(VerificationContextValidationError):
-            _canonical_json(object())
+            _canonical_json(val)
 
     def test_unordered_dict_keys(self):
         result = _canonical_json({"zebra": 1, "apple": 2})
@@ -610,12 +614,14 @@ class TestEsNumberFormatting:
         assert _es_number_to_string(1e-5) == "0.00001"
 
     def test_nan_rejected(self):
+        val = float("nan")
         with pytest.raises(VerificationContextValidationError):
-            _es_number_to_string(float("nan"))
+            _es_number_to_string(val)
 
     def test_infinity_rejected(self):
+        val = float("inf")
         with pytest.raises(VerificationContextValidationError):
-            _es_number_to_string(float("inf"))
+            _es_number_to_string(val)
 
 
 def _es_number_to_string(value):


### PR DESCRIPTION
## **User description**
Adds `qwed_infra/verification_context_bridge.py` converting `InfraDiagnosticResult` to Verification Context v1.0 document.

## What

- `verification_context_from_diagnostic_result()` — converts all 3 statuses
- VERIFIED without attestation demotes to UNVERIFIABLE (fail-closed, consistent with core contract)
- Evidence.payload preserves `InfraDiagnosticResult` fields and `audit_trace`
- Independent `qwed_infra/verification_context.py` model (no qwed-verification dependency), mirroring the canonical contract

## Behavior

| Input | verdict | admission | proof_ref |
|---|---|---|---|
| VERIFIED + attestation | VERIFIED | ADMIT | sha256:... |
| VERIFIED without attestation | UNVERIFIABLE | DENY | None |
| UNVERIFIABLE | UNVERIFIABLE | DENY | None |
| BLOCKED | BLOCKED | DENY | None |

## Files

- `qwed_infra/verification_context.py` (new) — VC v1.0 model (Verdict, Admission, VerificationContext, VerificationContextDocument, compute/resolve/is_valid)
- `qwed_infra/verification_context_bridge.py` (new) — InfraDiagnosticResult → VC bridge
- `qwed_infra/__init__.py` — exports

## Testing

377 tests pass (15 review rounds addressed across Greptile P1s, CodeRabbit, SonarCloud, QWED Security, Seer/Sentry findings). Bridge tested with VERIFIED (+/- attestation), UNVERIFIABLE, and BLOCKED inputs.

Closes #37
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standardized Verification Context v1.0 format for interpretations, proofs, evidence, decisions, and verdicts.
  * Added validation, serialization, canonical JSON generation, immutable value handling, and document integrity checks.
  * Added SHA-256 proof-reference creation and resolution.
  * Added conversion of diagnostic results into verification context documents with status mapping, evidence preservation, and attestation-aware verdict handling.
* **Bug Fixes**
  * Invalid or inconsistent verification data is now rejected or safely marked as unverifiable or blocked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Add fail-closed verification documents for infrastructure diagnostics

### What Changed
- Converts infrastructure diagnostic results into Verification Context v1.0 documents with matching verified, unverifiable, or blocked outcomes
- Requires an attestation before a verified result can be admitted; missing or malformed data is denied or blocked
- Preserves diagnostic details and audit history while keeping the document proof reference separate and bound to the document contents
- Adds document validation, immutable data handling, canonical proof generation, and package-level exports
- Adds coverage for status handling, proof integrity, malformed inputs, serialization, and Unicode validation

### Impact
`✅ Fail-closed admission for missing attestations`
`✅ Verifiable infrastructure decisions`
`✅ Preserved diagnostic audit trails`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
