### PR TITLE
feat: add IamGuard.to_verification_context() (#38)

### DIFF
--- a/qwed_infra/guards/iam_guard.py
+++ b/qwed_infra/guards/iam_guard.py
@@ -365,4 +365,22 @@ class IamGuard:
             evidence=evidence,
         )
 
+    def to_verification_context(
+        self,
+        result: "InfraDiagnosticResult",
+        formal_statement: str,
+        attestation_token: Optional[str] = None,
+    ) -> "VerificationContextDocument":
+        """Map an InfraDiagnosticResult to a Verification Context v1.0 document."""
+        from qwed_infra.verification_context_bridge import (
+            verification_context_from_diagnostic_result,
+        )
+
+        return verification_context_from_diagnostic_result(
+            result,
+            formal_statement=formal_statement,
+            attestation_token=attestation_token,
+            verifier="IamGuard",
+        )
+
 

--- a/qwed_infra/guards/iam_guard.py
+++ b/qwed_infra/guards/iam_guard.py
@@ -14,7 +14,8 @@ from qwed_infra.audit import (
     IAM_DENY_PRECEDENCE,
     build_trace,
 )
-from qwed_infra.diagnostics import InfraDiagnosticResult
+from qwed_infra.diagnostics import InfraDiagnosticResult, InfraDiagnosticStatus
+from qwed_infra.verification_context import VerificationContextDocument
 
 _IAM_CONSTRAINT_ID = "iam_guard.verify_access"
 
@@ -367,11 +368,25 @@ class IamGuard:
 
     def to_verification_context(
         self,
-        result: "InfraDiagnosticResult",
+        result: InfraDiagnosticResult,
         formal_statement: str,
         attestation_token: Optional[str] = None,
-    ) -> "VerificationContextDocument":
-        """Map an InfraDiagnosticResult to a Verification Context v1.0 document."""
+    ) -> VerificationContextDocument:
+        """Map an InfraDiagnosticResult to a Verification Context v1.0 document.
+
+        A verified IAM denial (allowed=False) must never be admissible: the
+        bridge grants ADMIT to every VERIFIED status, so a proven deny is
+        demoted to BLOCKED (fail-closed) before conversion.
+        """
+        if (
+            result.status is InfraDiagnosticStatus.VERIFIED
+            and result.developer_fields.get("allowed") is False
+        ):
+            result = InfraDiagnosticResult.blocked(
+                agent_message=result.agent_message,
+                developer_fields=result.developer_fields,
+            )
+
         from qwed_infra.verification_context_bridge import (
             verification_context_from_diagnostic_result,
         )

--- a/qwed_infra/guards/iam_guard.py
+++ b/qwed_infra/guards/iam_guard.py
@@ -376,16 +376,16 @@ class IamGuard:
 
         A verified IAM denial (allowed=False) must never be admissible: the
         bridge grants ADMIT to every VERIFIED status, so a proven deny is
-        demoted to BLOCKED (fail-closed) before conversion.
+        demoted to BLOCKED (fail-closed) via the decision override. The
+        evidence keeps the authoritative VERIFIED status and proof_ref so the
+        audit trail preserves the formal proof provenance.
         """
+        decision_status = None
         if (
             result.status is InfraDiagnosticStatus.VERIFIED
             and result.developer_fields.get("allowed") is False
         ):
-            result = InfraDiagnosticResult.blocked(
-                agent_message=result.agent_message,
-                developer_fields=result.developer_fields,
-            )
+            decision_status = InfraDiagnosticStatus.BLOCKED
 
         from qwed_infra.verification_context_bridge import (
             verification_context_from_diagnostic_result,
@@ -396,6 +396,7 @@ class IamGuard:
             formal_statement=formal_statement,
             attestation_token=attestation_token,
             verifier="IamGuard",
+            decision_status=decision_status,
         )
 
 

--- a/qwed_infra/verification_context_bridge.py
+++ b/qwed_infra/verification_context_bridge.py
@@ -8,6 +8,7 @@ Mirrors qwed-verification/src/qwed_new/core/verification_context_bridge.py.
 from __future__ import annotations
 
 import copy
+from dataclasses import replace
 from importlib.metadata import PackageNotFoundError, version
 from typing import Optional
 
@@ -165,12 +166,27 @@ def verification_context_from_diagnostic_result(
     verifier: str,
     verifier_version: Optional[str] = None,
     attestation_token: Optional[str] = None,
+    decision_status: Optional[InfraDiagnosticStatus] = None,
 ) -> VerificationContextDocument:
     _validate_inputs(result, formal_statement, verifier, attestation_token)
+    if decision_status is not None and not isinstance(
+        decision_status, InfraDiagnosticStatus
+    ):
+        raise VerificationContextValidationError(
+            "decision_status must be an InfraDiagnosticStatus or None"
+        )
 
     evidence_result = _cast_status_preserving(result)
     decision_result = _normalize_status(result)
     decision_result = _normalize_developer_fields(decision_result)
+    if decision_status is not None:
+        # Fail-closed decision override: evidence keeps the authoritative
+        # diagnostic (status + proof_ref), decision derives from decision_status.
+        decision_result = replace(
+            decision_result,
+            status=decision_status,
+            proof_ref=None,
+        )
     decision_result = _apply_attestation_policy(decision_result, attestation_token)
 
     interpretation = Interpretation(theory=f"{verifier} verification")

--- a/qwed_infra/verification_context_bridge.py
+++ b/qwed_infra/verification_context_bridge.py
@@ -169,12 +169,16 @@ def verification_context_from_diagnostic_result(
     decision_status: Optional[InfraDiagnosticStatus] = None,
 ) -> VerificationContextDocument:
     _validate_inputs(result, formal_statement, verifier, attestation_token)
-    if decision_status is not None and not isinstance(
-        decision_status, InfraDiagnosticStatus
-    ):
-        raise VerificationContextValidationError(
-            "decision_status must be an InfraDiagnosticStatus or None"
-        )
+    if decision_status is not None:
+        if not isinstance(decision_status, InfraDiagnosticStatus):
+            raise VerificationContextValidationError(
+                "decision_status must be an InfraDiagnosticStatus or None"
+            )
+        if decision_status is InfraDiagnosticStatus.VERIFIED:
+            raise VerificationContextValidationError(
+                "decision_status must be a fail-closed status "
+                "(UNVERIFIABLE or BLOCKED); VERIFIED is the default path"
+            )
 
     evidence_result = _cast_status_preserving(result)
     decision_result = _normalize_status(result)

--- a/tests/test_guard_diagnostics.py
+++ b/tests/test_guard_diagnostics.py
@@ -55,13 +55,21 @@ class TestIamGuardToVerificationContext:
         result = VerificationResult(verified=True, allowed=True, proof="Z3 sat")
         return IamGuard.to_diagnostic(result)
 
+    def _denied_diagnostic(self):
+        result = VerificationResult(verified=True, allowed=False, proof="Z3 unsat")
+        return IamGuard.to_diagnostic(result)
+
+    @staticmethod
+    def _attestation_token():
+        return "eyJhbGciOiJIUzI1NiJ9.attestation-signature"
+
     def test_verified_with_attestation(self):
         guard = IamGuard()
         diagnostic = self._verified_diagnostic()
         vc = guard.to_verification_context(
             diagnostic,
             formal_statement="IAM policy is safe to apply",
-            attestation_token="fake-jwt",
+            attestation_token=self._attestation_token(),
         )
         assert vc.verdict == Verdict.VERIFIED
         assert vc.context.decision.admission == Admission.ADMIT
@@ -70,6 +78,34 @@ class TestIamGuardToVerificationContext:
         doc_dict = vc.to_dict()
         assert is_valid_document(doc_dict) is True
         assert resolve_document_proof_ref(doc_dict) is True
+
+    def test_verified_denial_never_admissible(self):
+        guard = IamGuard()
+        diagnostic = self._denied_diagnostic()
+        assert diagnostic.status is InfraDiagnosticStatus.VERIFIED
+        vc = guard.to_verification_context(
+            diagnostic,
+            formal_statement="IAM policy is safe to apply",
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        assert is_valid_document(vc.to_dict()) is True
+        payload = vc.context.evidence.payload
+        assert payload["developer_fields"]["allowed"] is False
+        assert payload["developer_fields"]["proof"] == "Z3 unsat"
+
+    def test_verified_denial_without_attestation(self):
+        guard = IamGuard()
+        diagnostic = self._denied_diagnostic()
+        vc = guard.to_verification_context(
+            diagnostic,
+            formal_statement="IAM policy is safe to apply",
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
 
     def test_verified_without_attestation_demoted(self):
         guard = IamGuard()
@@ -122,7 +158,7 @@ class TestIamGuardToVerificationContext:
         vc = guard.to_verification_context(
             diagnostic,
             formal_statement="IAM policy is safe to apply",
-            attestation_token="fake-jwt",
+            attestation_token=self._attestation_token(),
         )
         assert vc.context.decision.admission is Admission.ADMIT
         assert diagnostic.is_verified is True
@@ -133,14 +169,23 @@ class TestIamGuardToVerificationContext:
         vc = guard.to_verification_context(
             diagnostic,
             formal_statement="IAM policy is safe to apply",
-            attestation_token="fake-jwt",
+            attestation_token=self._attestation_token(),
         )
         payload = vc.context.evidence.payload
         assert payload["developer_fields"]["constraint_id"] == "iam_guard.verify_access"
         assert payload["developer_fields"]["allowed"] is True
         assert payload["developer_fields"]["audit_trace"]["rule_id"] == "IAM_DENY_PRECEDENCE"
 
-    def test_empty_formal_statement_rejected(self):
+    @pytest.mark.parametrize(
+        "formal_statement",
+        [
+            "",
+            "   \n\t ",
+            123,
+            None,
+        ],
+    )
+    def test_invalid_formal_statement_rejected(self, formal_statement):
         from qwed_infra.verification_context import VerificationContextValidationError
 
         guard = IamGuard()
@@ -148,8 +193,8 @@ class TestIamGuardToVerificationContext:
         with pytest.raises(VerificationContextValidationError):
             guard.to_verification_context(
                 diagnostic,
-                formal_statement="",
-                attestation_token="fake-jwt",
+                formal_statement=formal_statement,
+                attestation_token=self._attestation_token(),
             )
 
     def test_existing_to_diagnostic_still_passes(self):

--- a/tests/test_guard_diagnostics.py
+++ b/tests/test_guard_diagnostics.py
@@ -83,6 +83,7 @@ class TestIamGuardToVerificationContext:
         guard = IamGuard()
         diagnostic = self._denied_diagnostic()
         assert diagnostic.status is InfraDiagnosticStatus.VERIFIED
+        original_proof_ref = diagnostic.proof_ref
         vc = guard.to_verification_context(
             diagnostic,
             formal_statement="IAM policy is safe to apply",
@@ -95,6 +96,7 @@ class TestIamGuardToVerificationContext:
         payload = vc.context.evidence.payload
         assert payload["developer_fields"]["allowed"] is False
         assert payload["developer_fields"]["proof"] == "Z3 unsat"
+        assert payload["diagnostic_proof_ref"] == original_proof_ref
 
     def test_verified_denial_without_attestation(self):
         guard = IamGuard()
@@ -190,11 +192,12 @@ class TestIamGuardToVerificationContext:
 
         guard = IamGuard()
         diagnostic = self._verified_diagnostic()
+        attestation_token = self._attestation_token()
         with pytest.raises(VerificationContextValidationError):
             guard.to_verification_context(
                 diagnostic,
                 formal_statement=formal_statement,
-                attestation_token=self._attestation_token(),
+                attestation_token=attestation_token,
             )
 
     def test_existing_to_diagnostic_still_passes(self):

--- a/tests/test_guard_diagnostics.py
+++ b/tests/test_guard_diagnostics.py
@@ -1,9 +1,15 @@
 import pydantic
 import pytest
-from qwed_infra.diagnostics import InfraDiagnosticStatus
+from qwed_infra.diagnostics import InfraDiagnosticResult, InfraDiagnosticStatus
 from qwed_infra.guards.iam_guard import IamGuard, VerificationResult
 from qwed_infra.guards.network_guard import ComputedPath, NetworkGuard
 from qwed_infra.guards.cost_guard import CostEstimate, CostGuard
+from qwed_infra.verification_context import (
+    Admission,
+    Verdict,
+    is_valid_document,
+    resolve_document_proof_ref,
+)
 
 
 class TestIamGuardToDiagnostic:
@@ -42,6 +48,115 @@ class TestIamGuardToDiagnostic:
         diagnostic = IamGuard.to_diagnostic(result, audit_trace=trace)
         assert diagnostic.developer_fields["audit_trace"] == trace
         assert diagnostic.audit_trace == trace
+
+
+class TestIamGuardToVerificationContext:
+    def _verified_diagnostic(self):
+        result = VerificationResult(verified=True, allowed=True, proof="Z3 sat")
+        return IamGuard.to_diagnostic(result)
+
+    def test_verified_with_attestation(self):
+        guard = IamGuard()
+        diagnostic = self._verified_diagnostic()
+        vc = guard.to_verification_context(
+            diagnostic,
+            formal_statement="IAM policy is safe to apply",
+            attestation_token="fake-jwt",
+        )
+        assert vc.verdict == Verdict.VERIFIED
+        assert vc.context.decision.admission == Admission.ADMIT
+        assert vc.context.evidence.proof_ref.startswith("sha256:")
+        assert len(vc.context.evidence.proof_ref) == 71
+        doc_dict = vc.to_dict()
+        assert is_valid_document(doc_dict) is True
+        assert resolve_document_proof_ref(doc_dict) is True
+
+    def test_verified_without_attestation_demoted(self):
+        guard = IamGuard()
+        diagnostic = self._verified_diagnostic()
+        vc = guard.to_verification_context(
+            diagnostic,
+            formal_statement="IAM policy is safe to apply",
+        )
+        assert vc.verdict == Verdict.UNVERIFIABLE
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        doc_dict = vc.to_dict()
+        assert is_valid_document(doc_dict) is True
+
+    def test_unverifiable(self):
+        guard = IamGuard()
+        result = VerificationResult(
+            verified=False,
+            allowed=False,
+            error="Solver failed",
+        )
+        diagnostic = IamGuard.to_diagnostic(result)
+        vc = guard.to_verification_context(
+            diagnostic,
+            formal_statement="IAM policy is safe to apply",
+        )
+        assert vc.verdict == Verdict.UNVERIFIABLE
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        assert is_valid_document(vc.to_dict()) is True
+
+    def test_blocked(self):
+        guard = IamGuard()
+        diagnostic = InfraDiagnosticResult.blocked(
+            agent_message="blocked by policy",
+            developer_fields={"constraint_id": "iam_guard.blocked", "reason": "explicit deny"},
+        )
+        vc = guard.to_verification_context(
+            diagnostic,
+            formal_statement="IAM policy is safe to apply",
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        assert is_valid_document(vc.to_dict()) is True
+
+    def test_admission_matches_diagnostic(self):
+        guard = IamGuard()
+        diagnostic = self._verified_diagnostic()
+        vc = guard.to_verification_context(
+            diagnostic,
+            formal_statement="IAM policy is safe to apply",
+            attestation_token="fake-jwt",
+        )
+        assert vc.context.decision.admission is Admission.ADMIT
+        assert diagnostic.is_verified is True
+
+    def test_evidence_preserves_diagnostic_fields(self):
+        guard = IamGuard()
+        diagnostic = self._verified_diagnostic()
+        vc = guard.to_verification_context(
+            diagnostic,
+            formal_statement="IAM policy is safe to apply",
+            attestation_token="fake-jwt",
+        )
+        payload = vc.context.evidence.payload
+        assert payload["developer_fields"]["constraint_id"] == "iam_guard.verify_access"
+        assert payload["developer_fields"]["allowed"] is True
+        assert payload["developer_fields"]["audit_trace"]["rule_id"] == "IAM_DENY_PRECEDENCE"
+
+    def test_empty_formal_statement_rejected(self):
+        from qwed_infra.verification_context import VerificationContextValidationError
+
+        guard = IamGuard()
+        diagnostic = self._verified_diagnostic()
+        with pytest.raises(VerificationContextValidationError):
+            guard.to_verification_context(
+                diagnostic,
+                formal_statement="",
+                attestation_token="fake-jwt",
+            )
+
+    def test_existing_to_diagnostic_still_passes(self):
+        result = VerificationResult(verified=True, allowed=True, proof="Z3 sat")
+        diagnostic = IamGuard.to_diagnostic(result)
+        assert diagnostic.status is InfraDiagnosticStatus.VERIFIED
+        assert diagnostic.proof_ref is not None
 
 
 class TestNetworkGuardToDiagnostic:

--- a/tests/test_verification_context.py
+++ b/tests/test_verification_context.py
@@ -863,6 +863,16 @@ class TestBridge:
                 decision_status="blocked",
             )
 
+    def test_decision_status_override_rejects_verified(self):
+        result = self._verified_result()
+        with pytest.raises(VerificationContextValidationError):
+            verification_context_from_diagnostic_result(
+                result,
+                formal_statement="test claim",
+                verifier="IamGuard",
+                decision_status=InfraDiagnosticStatus.VERIFIED,
+            )
+
     def test_empty_formal_statement_rejected(self):
         result = self._verified_result()
         with pytest.raises(VerificationContextValidationError):

--- a/tests/test_verification_context.py
+++ b/tests/test_verification_context.py
@@ -836,6 +836,33 @@ class TestBridge:
         assert vc.context.decision.admission == Admission.DENY
         assert vc.context.evidence.proof_ref is None
 
+    def test_decision_status_override_preserves_evidence(self):
+        result = self._verified_result()
+        vc = verification_context_from_diagnostic_result(
+            result,
+            formal_statement="test claim",
+            verifier="IamGuard",
+            attestation_token="fake-jwt",
+            decision_status=InfraDiagnosticStatus.BLOCKED,
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        payload = vc.context.evidence.payload
+        assert payload["status"] == "VERIFIED"
+        assert payload["diagnostic_proof_ref"] == result.proof_ref
+        assert is_valid_document(vc.to_dict()) is True
+
+    def test_decision_status_override_rejects_malformed_value(self):
+        result = self._verified_result()
+        with pytest.raises(VerificationContextValidationError):
+            verification_context_from_diagnostic_result(
+                result,
+                formal_statement="test claim",
+                verifier="IamGuard",
+                decision_status="blocked",
+            )
+
     def test_empty_formal_statement_rejected(self):
         result = self._verified_result()
         with pytest.raises(VerificationContextValidationError):


### PR DESCRIPTION
## **User description**
## Summary

Closes #38 — adds `IamGuard.to_verification_context()` mapping `InfraDiagnosticResult` to a Verification Context v1.0 document, following the qwed-verification verifier pattern and using the bridge from #37 (PR #44).

## Changes

### `qwed_infra/guards/iam_guard.py`
Adds `to_verification_context(result, formal_statement, attestation_token=None) -> VerificationContextDocument`:
- Delegates to `verification_context_from_diagnostic_result` with `verifier="IamGuard"`
- VERIFIED + attestation → `VERIFIED` / `ADMIT` with document-bound `proof_ref`
- VERIFIED without attestation → `UNVERIFIABLE` / `DENY` (fail-closed)
- UNVERIFIABLE → `UNVERIFIABLE` / `DENY`; BLOCKED → `BLOCKED` / `DENY`
- `proof_ref` is document-bound SHA-256 and resolves against the document

### `tests/test_guard_diagnostics.py`
New `TestIamGuardToVerificationContext` (8 tests):
- VERIFIED with/without attestation
- UNVERIFIABLE and BLOCKED mapping
- Admission matches diagnostic authority
- Evidence payload preserves `constraint_id` / `allowed` / `audit_trace`
- Empty `formal_statement` rejected (fail-closed)
- Schema validity + `resolve_document_proof_ref` for VERIFIED
- Existing `to_diagnostic()` behavior preserved

## Verification
- Full suite: **385 passed** (377 baseline + 8 new)
- Coverage: **93%** overall (IamGuard 95%, bridge 90%)
- `scripts/check_boundary.py` passes


___

## **CodeAnt-AI Description**
Add verification context output for IAM policy checks

### What Changed
- IAM checks can now be exported as Verification Context v1.0 documents
- Verified results are admitted only when an attestation is provided; otherwise they become unverifiable and are denied
- Unverifiable and blocked results are denied, with diagnostic evidence preserved in the document
- Generated documents validate correctly, including document-bound proof references; empty formal statements are rejected
- Existing IAM diagnostic behavior remains unchanged

### Impact
`✅ Fail-closed IAM admissions without attestation`
`✅ Verifiable IAM decisions with document-bound proof`
`✅ Preserved IAM evidence for audits`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for converting IAM diagnostic results into standardized Verification Context documents.
  * IAM denials are represented as blocked decisions while preserving the original evidence and proof provenance.
  * Supports formal statements, optional attestation tokens, verification statuses, admission decisions, and verifier identification.
  * Added validation for required statements, supported decision statuses, and generated documents.

* **Tests**
  * Added coverage for attested, denied, unverifiable, blocked, and evidence-preserving outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->