### PR TITLE
feat: add CostGuard.to_verification_context() (#40)

### DIFF
--- a/qwed_infra/guards/cost_guard.py
+++ b/qwed_infra/guards/cost_guard.py
@@ -1,5 +1,5 @@
 from decimal import Decimal, ROUND_HALF_UP
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 from pydantic import BaseModel
 from qwed_infra.audit import (
     COST_BUDGET_EXCEEDED,
@@ -7,8 +7,9 @@ from qwed_infra.audit import (
     COST_WITHIN_BUDGET,
     build_trace,
 )
-from qwed_infra.diagnostics import InfraDiagnosticResult
+from qwed_infra.diagnostics import InfraDiagnosticResult, InfraDiagnosticStatus
 from qwed_infra.numeric import decimal_text, parse_decimal_input
+from qwed_infra.verification_context import VerificationContextDocument
 
 _COST_CONSTRAINT_ID = "cost_guard.verify_budget"
 
@@ -265,4 +266,41 @@ class CostGuard:
                 "audit_trace": trace,
             },
             evidence={**trace, "total_monthly_cost": result.total_monthly_cost, "budget": result.budget},
+        )
+
+    def to_verification_context(
+        self,
+        resources: Dict[str, Any],
+        budget_monthly: object,
+        *,
+        formal_statement: str,
+        attestation_token: Optional[str] = None,
+    ) -> VerificationContextDocument:
+        """Run the budget check and map the result to a VC v1.0 document.
+
+        The guard performs the computation itself via verify_budget(), so a
+        caller cannot inject a result object of any kind. The provenance
+        gate remains as defense-in-depth: only a VERIFIED diagnostic
+        carrying CostGuard provenance and an explicit within_budget=True
+        outcome is admitted; anything else is BLOCKED.
+        """
+        result = self.verify_budget(resources, budget_monthly)
+        diagnostic = self.to_diagnostic(result)
+        decision_status = None
+        if diagnostic.status is InfraDiagnosticStatus.VERIFIED and not (
+            diagnostic.developer_fields.get("constraint_id") == _COST_CONSTRAINT_ID
+            and diagnostic.developer_fields.get("within_budget") is True
+        ):
+            decision_status = InfraDiagnosticStatus.BLOCKED
+
+        from qwed_infra.verification_context_bridge import (
+            verification_context_from_diagnostic_result,
+        )
+
+        return verification_context_from_diagnostic_result(
+            diagnostic,
+            formal_statement=formal_statement,
+            attestation_token=attestation_token,
+            verifier="CostGuard",
+            decision_status=decision_status,
         )

--- a/qwed_infra/guards/cost_guard.py
+++ b/qwed_infra/guards/cost_guard.py
@@ -279,13 +279,26 @@ class CostGuard:
         """Run the budget check and map the result to a VC v1.0 document.
 
         The guard performs the computation itself via verify_budget(), so a
-        caller cannot inject a result object of any kind. The provenance
-        gate remains as defense-in-depth: only a VERIFIED diagnostic
-        carrying CostGuard provenance and an explicit within_budget=True
-        outcome is admitted; anything else is BLOCKED.
+        caller cannot inject a result object of any kind. Malformed inputs
+        (undecimal budget, non-dict resources, non-dict entries) map to a
+        fail-closed BLOCKED diagnostic rather than propagating an exception.
+        The provenance gate remains as defense-in-depth: only a VERIFIED
+        diagnostic carrying CostGuard provenance and an explicit
+        within_budget=True outcome is admitted; anything else is BLOCKED.
         """
-        result = self.verify_budget(resources, budget_monthly)
-        diagnostic = self.to_diagnostic(result)
+        try:
+            result = self.verify_budget(resources, budget_monthly)
+        except (ValueError, TypeError, AttributeError):
+            diagnostic = InfraDiagnosticResult.blocked(
+                agent_message="Cost estimate could not be verified",
+                developer_fields={
+                    "constraint_id": _COST_CONSTRAINT_ID,
+                    "within_budget": False,
+                    "audit_trace": build_trace(COST_UNKNOWN_RESOURCE, "INVALID_INPUT"),
+                },
+            )
+        else:
+            diagnostic = self.to_diagnostic(result)
         decision_status = None
         if diagnostic.status is InfraDiagnosticStatus.VERIFIED and not (
             diagnostic.developer_fields.get("constraint_id") == _COST_CONSTRAINT_ID

--- a/qwed_infra/guards/cost_guard.py
+++ b/qwed_infra/guards/cost_guard.py
@@ -1,4 +1,4 @@
-from decimal import Decimal, ROUND_HALF_UP
+from decimal import Decimal, DecimalException, ROUND_HALF_UP
 from typing import Any, Dict, Optional
 from pydantic import BaseModel
 from qwed_infra.audit import (
@@ -12,6 +12,7 @@ from qwed_infra.numeric import decimal_text, parse_decimal_input
 from qwed_infra.verification_context import VerificationContextDocument
 
 _COST_CONSTRAINT_ID = "cost_guard.verify_budget"
+_INVALID_INPUT_MESSAGE = "Cost estimate could not be verified"
 
 TWO_PLACES = Decimal("0.01")
 
@@ -104,7 +105,7 @@ class CostGuard:
             unknown_instance_types.append("<missing>")
             return Decimal("0")
         count = inst.get("count", 1)
-        if not isinstance(count, int) or count < 1:
+        if isinstance(count, bool) or not isinstance(count, int) or count < 1:
             inst_id = inst.get("id") or inst_type
             key = self._unique_key(breakdown, f"invalid-count-{inst_id}")
             breakdown[key] = decimal_text(Decimal("0.00"))
@@ -133,7 +134,7 @@ class CostGuard:
             unknown_volume_types.append("<missing>")
             return Decimal("0")
         size_gb = vol.get("size_gb")
-        if not isinstance(size_gb, int) or size_gb < 1:
+        if isinstance(size_gb, bool) or not isinstance(size_gb, int) or size_gb < 1:
             key = self._unique_key(breakdown, f"invalid-size-{vol.get('id') or vol_type}")
             breakdown[key] = decimal_text(Decimal("0.00"))
             unknown_volume_types.append(f"invalid size_gb ({size_gb})")
@@ -187,7 +188,7 @@ class CostGuard:
             budget = parse_decimal_input(result.budget, "budget")
         except ValueError:
             return InfraDiagnosticResult.blocked(
-                agent_message="Cost estimate could not be verified",
+                agent_message=_INVALID_INPUT_MESSAGE,
                 developer_fields={
                     "constraint_id": _COST_CONSTRAINT_ID,
                     "within_budget": result.within_budget,
@@ -212,7 +213,7 @@ class CostGuard:
             )
             trace = build_trace(trace_rule, "INCONSISTENT")
             return InfraDiagnosticResult.blocked(
-                agent_message="Cost estimate could not be verified",
+                agent_message=_INVALID_INPUT_MESSAGE,
                 developer_fields={
                     "constraint_id": _COST_CONSTRAINT_ID,
                     "within_budget": result.within_budget,
@@ -288,9 +289,9 @@ class CostGuard:
         """
         try:
             result = self.verify_budget(resources, budget_monthly)
-        except (ValueError, TypeError, AttributeError):
+        except (ValueError, TypeError, AttributeError, DecimalException):
             diagnostic = InfraDiagnosticResult.blocked(
-                agent_message="Cost estimate could not be verified",
+                agent_message=_INVALID_INPUT_MESSAGE,
                 developer_fields={
                     "constraint_id": _COST_CONSTRAINT_ID,
                     "within_budget": False,

--- a/tests/test_guard_diagnostics.py
+++ b/tests/test_guard_diagnostics.py
@@ -678,6 +678,65 @@ class TestCostGuardToVerificationContext:
         assert vc.context.evidence.proof_ref is None
         assert is_valid_document(vc.to_dict()) is True
 
+    def test_extreme_budget_decimal_escape_blocked(self):
+        guard = CostGuard()
+        vc = guard.to_verification_context(
+            self._within_budget_resources(),
+            "1e1000000",
+            formal_statement="Estimated monthly cost is within the approved budget",
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        assert is_valid_document(vc.to_dict()) is True
+
+    def test_extreme_count_decimal_escape_blocked(self):
+        guard = CostGuard()
+        resources = {"instances": [{"id": "web", "instance_type": "t3.medium", "count": 10**24}]}
+        vc = guard.to_verification_context(
+            resources,
+            "100.00",
+            formal_statement="Estimated monthly cost is within the approved budget",
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        assert is_valid_document(vc.to_dict()) is True
+
+    @pytest.mark.parametrize("count", [True, False])
+    def test_boolean_count_blocked(self, count):
+        guard = CostGuard()
+        resources = {"instances": [{"id": "web", "instance_type": "t3.medium", "count": count}]}
+        vc = guard.to_verification_context(
+            resources,
+            "100.00",
+            formal_statement="Estimated monthly cost is within the approved budget",
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        payload = vc.context.evidence.payload
+        assert payload["developer_fields"]["has_unknown_types"] is True
+
+    @pytest.mark.parametrize("size_gb", [True, False])
+    def test_boolean_size_gb_blocked(self, size_gb):
+        guard = CostGuard()
+        resources = {"volumes": [{"id": "vol", "volume_type": "gp3", "size_gb": size_gb}]}
+        vc = guard.to_verification_context(
+            resources,
+            "100.00",
+            formal_statement="Estimated monthly cost is within the approved budget",
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        payload = vc.context.evidence.payload
+        assert payload["developer_fields"]["has_unknown_types"] is True
+
     def test_evidence_preserves_diagnostic_fields(self):
         guard = CostGuard()
         resources = self._within_budget_resources()

--- a/tests/test_guard_diagnostics.py
+++ b/tests/test_guard_diagnostics.py
@@ -641,6 +641,43 @@ class TestCostGuardToVerificationContext:
         assert payload["developer_fields"]["has_unknown_types"] is True
         assert payload["developer_fields"]["audit_trace"]["rule_id"] == "COST_UNKNOWN_RESOURCE"
 
+    def test_invalid_budget_input_never_admissible(self):
+        guard = CostGuard()
+        vc = guard.to_verification_context(
+            self._within_budget_resources(),
+            "not-a-number",
+            formal_statement="Estimated monthly cost is within the approved budget",
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        assert is_valid_document(vc.to_dict()) is True
+        payload = vc.context.evidence.payload
+        assert payload["developer_fields"]["within_budget"] is False
+        assert payload["developer_fields"]["audit_trace"]["outcome"] == "INVALID_INPUT"
+
+    @pytest.mark.parametrize(
+        "resources",
+        [
+            {"instances": [None]},
+            {"instances": None},
+            "not-a-dict",
+        ],
+    )
+    def test_malformed_resources_blocked(self, resources):
+        guard = CostGuard()
+        vc = guard.to_verification_context(
+            resources,
+            "100.00",
+            formal_statement="Estimated monthly cost is within the approved budget",
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        assert is_valid_document(vc.to_dict()) is True
+
     def test_evidence_preserves_diagnostic_fields(self):
         guard = CostGuard()
         resources = self._within_budget_resources()

--- a/tests/test_guard_diagnostics.py
+++ b/tests/test_guard_diagnostics.py
@@ -555,6 +555,132 @@ class TestCostGuardToDiagnostic:
         assert diagnostic.developer_fields["audit_trace"]["outcome"] == "INCONSISTENT"
 
 
+class TestCostGuardToVerificationContext:
+    @staticmethod
+    def _within_budget_resources():
+        return {"instances": [{"id": "web", "instance_type": "t3.medium", "count": 1}]}
+
+    @staticmethod
+    def _exceeds_budget_resources():
+        return {"instances": [{"id": "gpu", "instance_type": "p4d.24xlarge", "count": 1}]}
+
+    @staticmethod
+    def _unknown_type_resources():
+        return {"instances": [{"id": "gpu-1", "instance_type": "g6.xlarge", "count": 1}]}
+
+    @staticmethod
+    def _attestation_token():
+        return "attestation-fixture-opaque"
+
+    def test_within_budget_with_attestation(self):
+        guard = CostGuard()
+        resources = self._within_budget_resources()
+        vc = guard.to_verification_context(
+            resources,
+            "100.00",
+            formal_statement="Estimated monthly cost is within the approved budget",
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.VERIFIED
+        assert vc.context.decision.admission == Admission.ADMIT
+        assert vc.context.proof.verifier == "CostGuard"
+        assert vc.context.evidence.proof_ref.startswith("sha256:")
+        assert len(vc.context.evidence.proof_ref) == 71
+        doc_dict = vc.to_dict()
+        assert is_valid_document(doc_dict) is True
+        assert resolve_document_proof_ref(doc_dict) is True
+
+    def test_within_budget_without_attestation_demoted(self):
+        guard = CostGuard()
+        resources = self._within_budget_resources()
+        vc = guard.to_verification_context(
+            resources,
+            "100.00",
+            formal_statement="Estimated monthly cost is within the approved budget",
+        )
+        assert vc.verdict == Verdict.UNVERIFIABLE
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        assert is_valid_document(vc.to_dict()) is True
+
+    def test_exceeds_budget_never_admissible(self):
+        guard = CostGuard()
+        resources = self._exceeds_budget_resources()
+        result = guard.verify_budget(resources, "100.00")
+        assert result.within_budget is False
+        assert CostGuard.to_diagnostic(result).status is InfraDiagnosticStatus.BLOCKED
+        vc = guard.to_verification_context(
+            resources,
+            "100.00",
+            formal_statement="Estimated monthly cost is within the approved budget",
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        assert is_valid_document(vc.to_dict()) is True
+        payload = vc.context.evidence.payload
+        assert payload["developer_fields"]["within_budget"] is False
+        assert payload["developer_fields"]["audit_trace"]["rule_id"] == "COST_BUDGET_EXCEEDED"
+
+    def test_unknown_type_never_admissible(self):
+        guard = CostGuard()
+        resources = self._unknown_type_resources()
+        result = guard.verify_budget(resources, "100.00")
+        assert result.has_unknown_types is True
+        vc = guard.to_verification_context(
+            resources,
+            "100.00",
+            formal_statement="Estimated monthly cost is within the approved budget",
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        payload = vc.context.evidence.payload
+        assert payload["developer_fields"]["has_unknown_types"] is True
+        assert payload["developer_fields"]["audit_trace"]["rule_id"] == "COST_UNKNOWN_RESOURCE"
+
+    def test_evidence_preserves_diagnostic_fields(self):
+        guard = CostGuard()
+        resources = self._within_budget_resources()
+        vc = guard.to_verification_context(
+            resources,
+            "100.00",
+            formal_statement="Estimated monthly cost is within the approved budget",
+            attestation_token=self._attestation_token(),
+        )
+        payload = vc.context.evidence.payload
+        assert payload["developer_fields"]["constraint_id"] == "cost_guard.verify_budget"
+        assert payload["developer_fields"]["within_budget"] is True
+        assert payload["developer_fields"]["total_monthly_cost"] == "30.37"
+        assert payload["developer_fields"]["budget"] == "100.00"
+        assert payload["developer_fields"]["audit_trace"]["rule_id"] == "COST_WITHIN_BUDGET"
+
+    @pytest.mark.parametrize(
+        "formal_statement",
+        [
+            "",
+            "   \n\t ",
+            123,
+            None,
+        ],
+    )
+    def test_invalid_formal_statement_rejected(self, formal_statement):
+        from qwed_infra.verification_context import VerificationContextValidationError
+
+        guard = CostGuard()
+        resources = self._within_budget_resources()
+        attestation_token = self._attestation_token()
+        with pytest.raises(VerificationContextValidationError):
+            guard.to_verification_context(
+                resources,
+                "100.00",
+                formal_statement=formal_statement,
+                attestation_token=attestation_token,
+            )
+
+
 class TestPydanticExtraForbid:
     def test_iam_policy_rejects_extra(self):
         from qwed_infra.guards.iam_guard import IamPolicy


### PR DESCRIPTION
## **User description**
## Summary

Closes **#40** — adds `CostGuard.to_verification_context()` producing a Verification Context v1.0 document via the shared bridge, following the guard-computes-internally pattern established by #38 (IamGuard) and #39 (NetworkGuard).

## Security pattern

The guard **performs the computation itself** — no result object is accepted, so a caller cannot mint a `VERIFIED`/`ADMIT` document with a forged `CostEstimate`:

- `CostGuard.to_verification_context(resources, budget_monthly, *, formal_statement, attestation_token=None)` runs `verify_budget()` internally, then `to_diagnostic()`, then the shared bridge.

Fail-closed behavior:
- Within-budget + non-empty attestation → `VERIFIED`/`ADMIT` with document-bound `proof_ref`
- Within-budget without attestation → `UNVERIFIABLE`/`DENY`
- Exceeds-budget / unknown-resource-type / mismatched inputs → `BLOCKED`/`DENY` with null `proof_ref` (never ADMIT), even with an attestation
- Provenance gate retained as defense-in-depth: only a VERIFIED diagnostic carrying CostGuard provenance (`constraint_id`) and an explicit `within_budget=True` outcome is admitted

## Tests (`tests/test_guard_diagnostics.py`)

New `TestCostGuardToVerificationContext` (9 cases):
- Within-budget with/without attestation (VERIFIED/ADMIT vs UNVERIFIABLE/DENY)
- Exceeds-budget fail-closed with evidence preserved (`COST_BUDGET_EXCEEDED`, `within_budget=False`)
- Unknown-instance-type fail-closed (`COST_UNKNOWN_RESOURCE`, `has_unknown_types=True`)
- Evidence preserves `constraint_id`/`within_budget`/`total_monthly_cost`/`budget`/audit trace
- Invalid `formal_statement` boundaries (empty / whitespace-only / non-string) rejected
- All existing `to_diagnostic()` behavior preserved

## Verification

- Full suite: **414 passed** (405 baseline + 9 new)
- Coverage: **93%** overall (cost_guard.py 99%)
- `ruff` clean; `scripts/check_boundary.py` passes


___

## **CodeAnt-AI Description**
Add fail-closed cost verification contexts

### What Changed
- Cost checks can now produce a Verification Context document directly from the supplied resources and budget.
- Within-budget results are admitted only when a valid attestation is provided; without one, the document denies admission.
- Over-budget, unknown-resource, or inconsistent results are always blocked, with diagnostic evidence preserved.
- Invalid or empty formal statements are rejected, and the new behavior is covered by verification tests.

### Impact
`✅ Attested budget checks can be admitted`
`✅ Over-budget resources are never admitted`
`✅ Cost failure evidence remains available`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added verification documents for cost and budget checks.
  * Documents include diagnostic details, formal statements, and optional attestation proof references.
  * Verified results require valid budget status and cost-check provenance.

* **Bug Fixes**
  * Improved handling of exceeded budgets, unknown resources, malformed inputs, and demoted outcomes.
  * Boolean values are now rejected where numeric counts or sizes are required.
  * Invalid or unparseable numeric inputs fail safely with consistent blocked diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->