### PR TITLE
feat: add ArtifactBoundaryGuard.to_verification_context() (#41)

### DIFF
--- a/qwed_infra/guards/artifact_boundary_guard.py
+++ b/qwed_infra/guards/artifact_boundary_guard.py
@@ -83,25 +83,48 @@ class ArtifactBoundaryGuard:
 
     @staticmethod
     def _collect_package_files(package_dir: Path) -> tuple[list[Path], list[ArtifactBoundaryFinding]]:
-        """Collect package files; surface broken symlinks as findings (never silently omitted)."""
+        """Collect package files; surface broken symlinks and symlinked directories as findings (never silently omitted)."""
         findings = []
         files = []
         if not package_dir.is_dir():
             return files, findings
         for f in sorted(package_dir.rglob("*")):
-            if f.is_symlink() and not f.exists():
-                findings.append(
-                    ArtifactBoundaryFinding(
-                        finding_type="unknown_boundary",
-                        severity="BLOCK",
-                        file_path=str(f.relative_to(package_dir)),
-                        reason="Broken symlink in package boundary — target does not exist",
+            if f.is_symlink():
+                if not f.exists():
+                    findings.append(
+                        ArtifactBoundaryFinding(
+                            finding_type="unknown_boundary",
+                            severity="BLOCK",
+                            file_path=str(f.relative_to(package_dir)),
+                            reason="Broken symlink in package boundary — target does not exist",
+                        )
                     )
-                )
+                    continue
+                if f.is_dir():
+                    findings.append(
+                        ArtifactBoundaryFinding(
+                            finding_type="unknown_boundary",
+                            severity="BLOCK",
+                            file_path=str(f.relative_to(package_dir)),
+                            reason="Symlinked directory in package boundary — its target cannot be bound",
+                        )
+                    )
+                    continue
+                if f.is_file():
+                    files.append(f)  # symlinked files are resolved and contained in _content_manifest
                 continue
             if f.is_file():
                 files.append(f)
         return files, findings
+
+    @staticmethod
+    def _hash_file(path: Path) -> str:
+        """Stream-hash a file in fixed-size chunks (never full-memory)."""
+        digest = hashlib.sha256()
+        with path.open("rb") as fh:
+            for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
 
     @staticmethod
     def _content_manifest(pkg_path: Path, package_files: list[Path]) -> tuple[list[ArtifactBoundaryFinding], list[str]]:
@@ -138,7 +161,7 @@ class ArtifactBoundaryGuard:
                 )
                 return findings, []
             try:
-                digest = hashlib.sha256(resolved.read_bytes()).hexdigest()
+                digest = ArtifactBoundaryGuard._hash_file(resolved)
             except OSError as exc:
                 findings.append(
                     ArtifactBoundaryFinding(
@@ -339,6 +362,16 @@ class ArtifactBoundaryGuard:
             )
             return findings
         backend = backend_section.get("build-backend", "")
+        if not isinstance(backend, str):
+            findings.append(
+                ArtifactBoundaryFinding(
+                    finding_type="unknown_boundary",
+                    severity="BLOCK",
+                    file_path=pp_name,
+                    reason="Invalid build-backend shape (must be a string) — packaging rules unverifiable",
+                )
+            )
+            return findings
         node = data
         wheel = {}
         for key in ("tool", "hatch", "build", "targets", "wheel"):

--- a/qwed_infra/guards/artifact_boundary_guard.py
+++ b/qwed_infra/guards/artifact_boundary_guard.py
@@ -1,4 +1,5 @@
 import fnmatch
+import hashlib
 from pathlib import Path
 from typing import List, Optional
 from pydantic import BaseModel
@@ -61,6 +62,7 @@ class ArtifactBoundaryResult(BaseModel):
     findings: List[ArtifactBoundaryFinding]
     package_files: List[str]
     reason: str
+    content_manifest: List[str] = []
 
 
 class ArtifactBoundaryGuard:
@@ -82,6 +84,28 @@ class ArtifactBoundaryGuard:
             if f.is_file():
                 files.append(f)
         return sorted(files)
+
+    @staticmethod
+    def _content_manifest(pkg_path: Path, package_files: list[Path]) -> tuple[list[ArtifactBoundaryFinding], list[str]]:
+        """Bind each collected package file to its sha256 content digest (sorted)."""
+        manifest_items = []
+        findings = []
+        for f in package_files:
+            rel = str(f.relative_to(pkg_path))
+            try:
+                digest = hashlib.sha256(f.read_bytes()).hexdigest()
+            except OSError as exc:
+                findings.append(
+                    ArtifactBoundaryFinding(
+                        finding_type="unknown_boundary",
+                        severity="BLOCK",
+                        file_path=rel,
+                        reason=f"Could not hash '{rel}' for the artifact manifest — cannot bind contents: {exc}",
+                    )
+                )
+                return findings, []
+            manifest_items.append(f"{rel}={digest}")
+        return findings, sorted(manifest_items)
 
     @staticmethod
     def _try_load_toml(pyproject_path: Path, pp_name: str):
@@ -113,7 +137,32 @@ class ArtifactBoundaryGuard:
             ]
 
     @staticmethod
-    def _check_wheel_packages(packages, package_name: str, pp_name: str) -> tuple[list[ArtifactBoundaryFinding], bool]:
+    def _entry_within_boundary(entry: str, package_name: str, base_dir: Path, boundary_dir: Path) -> tuple[bool, str | None]:
+        """Check a wheel entry stays inside the scanned package boundary.
+
+        - package_name must appear as a path component of the entry
+        - entry cannot be absolute or contain '..' traversal
+        - resolved path must live under package_dir
+        Returns (is_allowed, rejection_reason).
+        """
+        entry_path = Path(entry)
+        if entry_path.is_absolute():
+            return False, f"wheel entry '{entry}' is an absolute path, outside boundary '{package_name}'"
+        if ".." in entry_path.parts:
+            return False, f"wheel entry '{entry}' escapes boundary '{package_name}'"
+        if package_name not in entry_path.parts:
+            return False, f"Package '{package_name}' not referenced by wheel entry '{entry}'"
+        resolved_entry = (base_dir / entry_path).resolve()
+        resolved_boundary = boundary_dir.resolve()
+        try:
+            if resolved_boundary not in resolved_entry.parents and resolved_entry != resolved_boundary:
+                return False, f"wheel entry '{entry}' resolves outside inspected boundary '{package_name}'"
+        except OSError:
+            return False, f"wheel entry '{entry}' could not be resolved within '{package_name}'"
+        return True, None
+
+    @staticmethod
+    def _check_wheel_packages(packages, package_name: str, pp_name: str, base_dir: Path, boundary_dir: Path) -> tuple[list[ArtifactBoundaryFinding], bool]:
         findings = []
         if not isinstance(packages, list) or not all(isinstance(p, str) for p in packages):
             findings.append(
@@ -136,30 +185,23 @@ class ArtifactBoundaryGuard:
             )
             return findings, False
         for pkg in packages:
-            if package_name not in Path(pkg).parts:
+            allowed, reason = ArtifactBoundaryGuard._entry_within_boundary(
+                pkg, package_name, base_dir, boundary_dir
+            )
+            if not allowed:
                 findings.append(
                     ArtifactBoundaryFinding(
                         finding_type="missing_control",
                         severity="BLOCK",
                         file_path=pp_name,
-                        reason=f"Package '{pkg}' in wheel packages is outside verified boundary '{package_name}'",
+                        reason=reason,
                     )
                 )
                 return findings, False
-        if not any(package_name in Path(p).parts for p in packages):
-            findings.append(
-                ArtifactBoundaryFinding(
-                    finding_type="missing_control",
-                    severity="BLOCK",
-                    file_path=pp_name,
-                    reason=f"Package '{package_name}' not listed in [tool.hatch.build.targets.wheel].packages",
-                )
-            )
-            return findings, False
         return findings, True
 
     @staticmethod
-    def _check_wheel_only_include(only_include, package_name: str, pp_name: str) -> list[ArtifactBoundaryFinding]:
+    def _check_wheel_only_include(only_include, package_name: str, pp_name: str, base_dir: Path, boundary_dir: Path) -> list[ArtifactBoundaryFinding]:
         findings = []
         if not isinstance(only_include, list) or not all(isinstance(e, str) for e in only_include):
             findings.append(
@@ -174,7 +216,10 @@ class ArtifactBoundaryGuard:
         if only_include:
             has_valid = False
             for entry in only_include:
-                if package_name in Path(entry).parts:
+                allowed, reason = ArtifactBoundaryGuard._entry_within_boundary(
+                    entry, package_name, base_dir, boundary_dir
+                )
+                if allowed:
                     has_valid = True
                 else:
                     findings.append(
@@ -182,7 +227,7 @@ class ArtifactBoundaryGuard:
                             finding_type="missing_control",
                             severity="BLOCK",
                             file_path=pp_name,
-                            reason=f"only-include entry '{entry}' is outside verified boundary '{package_name}'",
+                            reason=reason,
                         )
                     )
             if not has_valid:
@@ -197,16 +242,16 @@ class ArtifactBoundaryGuard:
         return findings
 
     @staticmethod
-    def _check_wheel_config(wheel, package_name: str, pp_name: str) -> list[ArtifactBoundaryFinding]:
+    def _check_wheel_config(wheel, package_name: str, pp_name: str, base_dir: Path, boundary_dir: Path) -> list[ArtifactBoundaryFinding]:
         findings = []
         pkg_findings, ok = ArtifactBoundaryGuard._check_wheel_packages(
-            wheel.get("packages", []), package_name, pp_name
+            wheel.get("packages", []), package_name, pp_name, base_dir, boundary_dir
         )
         if not ok:
             return pkg_findings
         findings.extend(pkg_findings)
         only_include = wheel.get("only-include", [])
-        findings.extend(ArtifactBoundaryGuard._check_wheel_only_include(only_include, package_name, pp_name))
+        findings.extend(ArtifactBoundaryGuard._check_wheel_only_include(only_include, package_name, pp_name, base_dir, boundary_dir))
         if not wheel.get("only-packages", False):
             widening = [opt for opt in ("include", "artifacts", "force-include") if wheel.get(opt)]
             if widening:
@@ -259,6 +304,17 @@ class ArtifactBoundaryGuard:
         else:
             wheel = node
         if backend and not backend.startswith("hatchling"):
+            findings.append(
+                ArtifactBoundaryFinding(
+                    finding_type="unknown_boundary",
+                    severity="BLOCK",
+                    file_path=pp_name,
+                    reason=(
+                        f"Unsupported build backend '{backend}' — packaging rules are "
+                        "not modeled, so the built-wheel boundary cannot be verified"
+                    ),
+                )
+            )
             return findings
         if not isinstance(wheel, dict):
             findings.append(
@@ -272,7 +328,8 @@ class ArtifactBoundaryGuard:
             return findings
         if not wheel:
             return findings
-        findings.extend(ArtifactBoundaryGuard._check_wheel_config(wheel, package_name, pp_name))
+        boundary_dir = pyproject_path.parent / package_name
+        findings.extend(ArtifactBoundaryGuard._check_wheel_config(wheel, package_name, pp_name, pyproject_path.parent, boundary_dir))
         return findings
 
     def verify_package_boundary(
@@ -302,6 +359,17 @@ class ArtifactBoundaryGuard:
 
         package_files = self._collect_package_files(pkg_path)
         rel_paths = [str(f.relative_to(pkg_path)) for f in package_files]
+
+        # Bind evidence to contents: hash every collected file, sorted.
+        content_findings, content_manifest = self._content_manifest(pkg_path, package_files)
+        if content_findings:
+            return ArtifactBoundaryResult(
+                is_safe=False,
+                findings=content_findings,
+                package_files=rel_paths,
+                reason="Package boundary could not be verified — could not hash contents",
+                content_manifest=[],
+            )
 
         for f in package_files:
             rel_path = f.relative_to(pkg_path)
@@ -364,6 +432,7 @@ class ArtifactBoundaryGuard:
             findings=findings,
             package_files=rel_paths,
             reason=reason,
+            content_manifest=content_manifest,
         )
 
     @staticmethod
@@ -389,6 +458,7 @@ class ArtifactBoundaryGuard:
         if result.is_safe:
             trace = build_trace(ARTIFACT_BOUNDARY_VERIFIED, "ALLOWED")
             manifest = sorted(result.package_files)
+            content_manifest = sorted(result.content_manifest)
             return InfraDiagnosticResult.verified(
                 agent_message="Package boundary verified — safe to publish",
                 developer_fields={
@@ -396,12 +466,18 @@ class ArtifactBoundaryGuard:
                     "is_safe": result.is_safe,
                     "file_count": len(result.package_files),
                     "file_paths": manifest,
+                    "content_manifest": content_manifest,
                     "findings": [f.model_dump() for f in result.findings],
                     "reason": result.reason,
                     "audit_trace": trace,
                     "rule_ids": [ARTIFACT_BOUNDARY_VERIFIED.rule_id],
                 },
-                evidence={**trace, "file_count": len(result.package_files), "file_paths": manifest},
+                evidence={
+                    **trace,
+                    "file_count": len(result.package_files),
+                    "file_paths": manifest,
+                    "content_manifest": content_manifest,
+                },
             )
 
         finding_types = sorted({f.finding_type for f in blocked}, key=ArtifactBoundaryGuard._finding_priority)

--- a/qwed_infra/guards/artifact_boundary_guard.py
+++ b/qwed_infra/guards/artifact_boundary_guard.py
@@ -17,6 +17,12 @@ from qwed_infra.verification_context import VerificationContextDocument
 
 _ARTIFACT_CONSTRAINT_ID = "artifact_boundary_guard.verify_package_boundary"
 
+# Only build backends whose packaging/wheel rules are fully modeled may be
+# admitted. Everything else (missing, setuptools, flit, hatchling.* spoofing,
+# etc.) is unverifiable -> BLOCKED. Exact-match allowlist: no prefix matching,
+# so "hatchling.malicious" is not accepted.
+_SUPPORTED_BUILD_BACKENDS = frozenset({"hatchling.build"})
+
 SENSITIVE_FILE_PATTERNS = [
     "*.pem", "*.key", "*.pgp", "*.gpg",
     ".env", ".env.*",
@@ -76,24 +82,63 @@ class ArtifactBoundaryGuard:
         return False
 
     @staticmethod
-    def _collect_package_files(package_dir: Path) -> list[Path]:
-        if not package_dir.is_dir():
-            return []
+    def _collect_package_files(package_dir: Path) -> tuple[list[Path], list[ArtifactBoundaryFinding]]:
+        """Collect package files; surface broken symlinks as findings (never silently omitted)."""
+        findings = []
         files = []
-        for f in package_dir.rglob("*"):
+        if not package_dir.is_dir():
+            return files, findings
+        for f in sorted(package_dir.rglob("*")):
+            if f.is_symlink() and not f.exists():
+                findings.append(
+                    ArtifactBoundaryFinding(
+                        finding_type="unknown_boundary",
+                        severity="BLOCK",
+                        file_path=str(f.relative_to(package_dir)),
+                        reason="Broken symlink in package boundary — target does not exist",
+                    )
+                )
+                continue
             if f.is_file():
                 files.append(f)
-        return sorted(files)
+        return files, findings
 
     @staticmethod
     def _content_manifest(pkg_path: Path, package_files: list[Path]) -> tuple[list[ArtifactBoundaryFinding], list[str]]:
-        """Bind each collected package file to its sha256 content digest (sorted)."""
+        """Bind each collected package file to its sha256 content digest (sorted).
+
+        Every file is strictly resolved first: broken links and targets outside
+        the scanned package_dir are rejected (fail-closed).
+        """
+        resolved_pkg = pkg_path.resolve()
         manifest_items = []
         findings = []
         for f in package_files:
             rel = str(f.relative_to(pkg_path))
             try:
-                digest = hashlib.sha256(f.read_bytes()).hexdigest()
+                resolved = f.resolve(strict=True)
+            except (OSError, RuntimeError) as exc:
+                findings.append(
+                    ArtifactBoundaryFinding(
+                        finding_type="unknown_boundary",
+                        severity="BLOCK",
+                        file_path=rel,
+                        reason=f"Could not resolve '{rel}' for the artifact manifest — {exc}",
+                    )
+                )
+                return findings, []
+            if resolved != resolved_pkg and resolved_pkg not in resolved.parents:
+                findings.append(
+                    ArtifactBoundaryFinding(
+                        finding_type="unknown_boundary",
+                        severity="BLOCK",
+                        file_path=rel,
+                        reason=f"Package member '{rel}' resolves outside the scanned boundary",
+                    )
+                )
+                return findings, []
+            try:
+                digest = hashlib.sha256(resolved.read_bytes()).hexdigest()
             except OSError as exc:
                 findings.append(
                     ArtifactBoundaryFinding(
@@ -152,12 +197,12 @@ class ArtifactBoundaryGuard:
             return False, f"wheel entry '{entry}' escapes boundary '{package_name}'"
         if package_name not in entry_path.parts:
             return False, f"Package '{package_name}' not referenced by wheel entry '{entry}'"
-        resolved_entry = (base_dir / entry_path).resolve()
-        resolved_boundary = boundary_dir.resolve()
         try:
+            resolved_entry = (base_dir / entry_path).resolve()
+            resolved_boundary = boundary_dir.resolve()
             if resolved_boundary not in resolved_entry.parents and resolved_entry != resolved_boundary:
                 return False, f"wheel entry '{entry}' resolves outside inspected boundary '{package_name}'"
-        except OSError:
+        except (OSError, RuntimeError):
             return False, f"wheel entry '{entry}' could not be resolved within '{package_name}'"
         return True, None
 
@@ -266,7 +311,7 @@ class ArtifactBoundaryGuard:
         return findings
 
     @staticmethod
-    def _check_build_config(pyproject_path: Path, package_name: str) -> list[ArtifactBoundaryFinding]:
+    def _check_build_config(pyproject_path: Path, package_name: str, boundary_dir: Path) -> list[ArtifactBoundaryFinding]:
         findings = []
         pp_name = pyproject_path.name
         if not pyproject_path.is_file():
@@ -303,15 +348,15 @@ class ArtifactBoundaryGuard:
             node = node.get(key, {})
         else:
             wheel = node
-        if backend and not backend.startswith("hatchling"):
+        if backend not in _SUPPORTED_BUILD_BACKENDS:
             findings.append(
                 ArtifactBoundaryFinding(
                     finding_type="unknown_boundary",
                     severity="BLOCK",
                     file_path=pp_name,
                     reason=(
-                        f"Unsupported build backend '{backend}' — packaging rules are "
-                        "not modeled, so the built-wheel boundary cannot be verified"
+                        f"Unsupported or missing build backend '{backend or '<none>'}' — "
+                        "packaging rules are not modeled, so the built-wheel boundary cannot be verified"
                     ),
                 )
             )
@@ -328,7 +373,6 @@ class ArtifactBoundaryGuard:
             return findings
         if not wheel:
             return findings
-        boundary_dir = pyproject_path.parent / package_name
         findings.extend(ArtifactBoundaryGuard._check_wheel_config(wheel, package_name, pp_name, pyproject_path.parent, boundary_dir))
         return findings
 
@@ -357,7 +401,8 @@ class ArtifactBoundaryGuard:
                 reason="Package boundary could not be verified — directory not found",
             )
 
-        package_files = self._collect_package_files(pkg_path)
+        package_files, symlink_findings = self._collect_package_files(pkg_path)
+        findings.extend(symlink_findings)
         rel_paths = [str(f.relative_to(pkg_path)) for f in package_files]
 
         # Bind evidence to contents: hash every collected file, sorted.
@@ -417,7 +462,7 @@ class ArtifactBoundaryGuard:
                     )
                 )
 
-        findings.extend(self._check_build_config(pyproj_path, package_name))
+        findings.extend(self._check_build_config(pyproj_path, package_name, boundary_dir=pkg_path))
 
         is_safe = len(findings) == 0
         if is_safe:

--- a/qwed_infra/guards/artifact_boundary_guard.py
+++ b/qwed_infra/guards/artifact_boundary_guard.py
@@ -237,8 +237,27 @@ class ArtifactBoundaryGuard:
         data, err = ArtifactBoundaryGuard._try_load_toml(pyproject_path, pp_name)
         if err:
             return err
-        backend = data.get("build-system", {}).get("build-backend", "")
-        wheel = data.get("tool", {}).get("hatch", {}).get("build", {}).get("targets", {}).get("wheel", {})
+        backend_section = data.get("build-system", {})
+        if not isinstance(backend_section, dict):
+            findings.append(
+                ArtifactBoundaryFinding(
+                    finding_type="unknown_boundary",
+                    severity="BLOCK",
+                    file_path=pp_name,
+                    reason="Invalid [build-system] shape — packaging rules unverifiable",
+                )
+            )
+            return findings
+        backend = backend_section.get("build-backend", "")
+        node = data
+        wheel = {}
+        for key in ("tool", "hatch", "build", "targets", "wheel"):
+            if not isinstance(node, dict):
+                wheel = None  # mis-shaped intermediate section
+                break
+            node = node.get(key, {})
+        else:
+            wheel = node
         if backend and not backend.startswith("hatchling"):
             return findings
         if not isinstance(wheel, dict):
@@ -369,18 +388,20 @@ class ArtifactBoundaryGuard:
 
         if result.is_safe:
             trace = build_trace(ARTIFACT_BOUNDARY_VERIFIED, "ALLOWED")
+            manifest = sorted(result.package_files)
             return InfraDiagnosticResult.verified(
                 agent_message="Package boundary verified — safe to publish",
                 developer_fields={
                     "constraint_id": _ARTIFACT_CONSTRAINT_ID,
                     "is_safe": result.is_safe,
                     "file_count": len(result.package_files),
+                    "file_paths": manifest,
                     "findings": [f.model_dump() for f in result.findings],
                     "reason": result.reason,
                     "audit_trace": trace,
                     "rule_ids": [ARTIFACT_BOUNDARY_VERIFIED.rule_id],
                 },
-                evidence={**trace, "file_count": len(result.package_files)},
+                evidence={**trace, "file_count": len(result.package_files), "file_paths": manifest},
             )
 
         finding_types = sorted({f.finding_type for f in blocked}, key=ArtifactBoundaryGuard._finding_priority)
@@ -405,7 +426,6 @@ class ArtifactBoundaryGuard:
         self,
         package_dir: str = "qwed_infra",
         pyproject_path: str | None = None,
-        package_name: str = "qwed_infra",
         *,
         formal_statement: str,
         attestation_token: Optional[str] = None,
@@ -414,12 +434,29 @@ class ArtifactBoundaryGuard:
 
         The guard performs the computation itself via verify_package_boundary()
         against the real filesystem, so a caller cannot inject a result object.
+        The package identity is derived from the inspected package_dir, so a
+        caller cannot scan one directory while checking wheel configuration for
+        another. Malformed inputs and unexpected verification failures map to a
+        fail-closed BLOCKED diagnostic rather than propagating an exception.
         The provenance gate remains as defense-in-depth: only a VERIFIED
         diagnostic carrying ArtifactBoundaryGuard provenance and an explicit
         is_safe=True outcome is admitted; anything else is BLOCKED.
         """
-        result = self.verify_package_boundary(package_dir, pyproject_path, package_name)
-        diagnostic = self.to_diagnostic(result)
+        try:
+            # Bind package identity to the directory actually scanned.
+            package_name = Path(package_dir).name
+            result = self.verify_package_boundary(package_dir, pyproject_path, package_name)
+        except (TypeError, ValueError, AttributeError, KeyError, OSError):
+            diagnostic = InfraDiagnosticResult.blocked(
+                agent_message="Package boundary could not be verified",
+                developer_fields={
+                    "constraint_id": _ARTIFACT_CONSTRAINT_ID,
+                    "is_safe": False,
+                    "audit_trace": build_trace(ARTIFACT_UNKNOWN_BOUNDARY, "INVALID_INPUT"),
+                },
+            )
+        else:
+            diagnostic = self.to_diagnostic(result)
         decision_status = None
         if diagnostic.status is InfraDiagnosticStatus.VERIFIED and not (
             diagnostic.developer_fields.get("constraint_id") == _ARTIFACT_CONSTRAINT_ID

--- a/qwed_infra/guards/artifact_boundary_guard.py
+++ b/qwed_infra/guards/artifact_boundary_guard.py
@@ -1,6 +1,6 @@
 import fnmatch
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 from pydantic import BaseModel
 from qwed_infra.audit import (
     ARTIFACT_BOUNDARY_VERIFIED,
@@ -11,7 +11,8 @@ from qwed_infra.audit import (
     ARTIFACT_UNKNOWN_BOUNDARY,
     build_trace,
 )
-from qwed_infra.diagnostics import InfraDiagnosticResult
+from qwed_infra.diagnostics import InfraDiagnosticResult, InfraDiagnosticStatus
+from qwed_infra.verification_context import VerificationContextDocument
 
 _ARTIFACT_CONSTRAINT_ID = "artifact_boundary_guard.verify_package_boundary"
 
@@ -398,4 +399,42 @@ class ArtifactBoundaryGuard:
                 "audit_trace": trace,
                 "rule_ids": rule_ids,
             },
+        )
+
+    def to_verification_context(
+        self,
+        package_dir: str = "qwed_infra",
+        pyproject_path: str | None = None,
+        package_name: str = "qwed_infra",
+        *,
+        formal_statement: str,
+        attestation_token: Optional[str] = None,
+    ) -> VerificationContextDocument:
+        """Run the package-boundary check and map the result to a VC v1.0 document.
+
+        The guard performs the computation itself via verify_package_boundary()
+        against the real filesystem, so a caller cannot inject a result object.
+        The provenance gate remains as defense-in-depth: only a VERIFIED
+        diagnostic carrying ArtifactBoundaryGuard provenance and an explicit
+        is_safe=True outcome is admitted; anything else is BLOCKED.
+        """
+        result = self.verify_package_boundary(package_dir, pyproject_path, package_name)
+        diagnostic = self.to_diagnostic(result)
+        decision_status = None
+        if diagnostic.status is InfraDiagnosticStatus.VERIFIED and not (
+            diagnostic.developer_fields.get("constraint_id") == _ARTIFACT_CONSTRAINT_ID
+            and diagnostic.developer_fields.get("is_safe") is True
+        ):
+            decision_status = InfraDiagnosticStatus.BLOCKED
+
+        from qwed_infra.verification_context_bridge import (
+            verification_context_from_diagnostic_result,
+        )
+
+        return verification_context_from_diagnostic_result(
+            diagnostic,
+            formal_statement=formal_statement,
+            attestation_token=attestation_token,
+            verifier="ArtifactBoundaryGuard",
+            decision_status=decision_status,
         )

--- a/qwed_infra/guards/artifact_boundary_guard.py
+++ b/qwed_infra/guards/artifact_boundary_guard.py
@@ -372,6 +372,14 @@ class ArtifactBoundaryGuard:
             )
             return findings
         if not wheel:
+            findings.append(
+                ArtifactBoundaryFinding(
+                    finding_type="missing_control",
+                    severity="BLOCK",
+                    file_path=pp_name,
+                    reason="No [tool.hatch.build.targets.wheel] section — the declared wheel packaging boundary is missing",
+                )
+            )
             return findings
         findings.extend(ArtifactBoundaryGuard._check_wheel_config(wheel, package_name, pp_name, pyproject_path.parent, boundary_dir))
         return findings
@@ -408,9 +416,10 @@ class ArtifactBoundaryGuard:
         # Bind evidence to contents: hash every collected file, sorted.
         content_findings, content_manifest = self._content_manifest(pkg_path, package_files)
         if content_findings:
+            findings.extend(content_findings)
             return ArtifactBoundaryResult(
                 is_safe=False,
-                findings=content_findings,
+                findings=findings,
                 package_files=rel_paths,
                 reason="Package boundary could not be verified — could not hash contents",
                 content_manifest=[],
@@ -567,7 +576,7 @@ class ArtifactBoundaryGuard:
             # Bind package identity to the directory actually scanned.
             package_name = Path(package_dir).name
             result = self.verify_package_boundary(package_dir, pyproject_path, package_name)
-        except (TypeError, ValueError, AttributeError, KeyError, OSError):
+        except (TypeError, ValueError, AttributeError, KeyError, OSError, RuntimeError):
             diagnostic = InfraDiagnosticResult.blocked(
                 agent_message="Package boundary could not be verified",
                 developer_fields={

--- a/tests/test_artifact_boundary_guard.py
+++ b/tests/test_artifact_boundary_guard.py
@@ -334,13 +334,33 @@ def test_file_named_tests_not_excluded(guard, tmp_path):
     assert any("tests" in f for f in result.package_files)
 
 
-def test_only_include_with_path_entries_passes(guard, tmp_path):
+def test_only_include_with_path_entries_outside_blocked(guard, tmp_path):
+    """only-include entries that resolve outside the scanned package_dir are
+    rejected (wheel could widen the boundary beyond what was inspected)."""
     pkg = tmp_path / "mypkg"
     pkg.mkdir(parents=True)
     _write_file(pkg / "__init__.py")
     _write_file(
         tmp_path / "pyproject.toml",
         "[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\nonly-include = ['src/mypkg', 'mypkg/extra']\n",
+    )
+    result = guard.verify_package_boundary(
+        package_dir=str(pkg), pyproject_path=str(tmp_path / "pyproject.toml"),
+        package_name="mypkg",
+    )
+    assert result.is_safe is False
+    assert any(f.finding_type == "missing_control" for f in result.findings)
+
+
+def test_only_include_within_boundary_passes(guard, tmp_path):
+    """only-include entries resolving inside the scanned package_dir pass."""
+    pkg = tmp_path / "mypkg"
+    pkg.mkdir(parents=True)
+    _write_file(pkg / "__init__.py")
+    _write_file(pkg / "sub" / "extra.py")
+    _write_file(
+        tmp_path / "pyproject.toml",
+        "[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\nonly-include = ['mypkg', 'mypkg/sub']\n",
     )
     result = guard.verify_package_boundary(
         package_dir=str(pkg), pyproject_path=str(tmp_path / "pyproject.toml"),
@@ -363,7 +383,7 @@ def test_default_pyproject_path_resolved_from_package_dir(guard, tmp_path):
     assert result.is_safe is True
 
 
-def test_non_hatch_backend_skips_wheel_check(guard, tmp_path):
+def test_non_hatch_backend_blocked(guard, tmp_path):
     pkg = tmp_path / "mypkg"
     pkg.mkdir(parents=True)
     _write_file(pkg / "__init__.py")
@@ -375,4 +395,5 @@ def test_non_hatch_backend_skips_wheel_check(guard, tmp_path):
         package_dir=str(pkg), pyproject_path=str(tmp_path / "pyproject.toml"),
         package_name="mypkg",
     )
-    assert result.is_safe is True
+    assert result.is_safe is False
+    assert any(f.finding_type == "unknown_boundary" for f in result.findings)

--- a/tests/test_artifact_boundary_guard.py
+++ b/tests/test_artifact_boundary_guard.py
@@ -29,7 +29,7 @@ def test_to_diagnostic_verified(guard, tmp_path):
     _write_file(pkg / "__init__.py")
     _write_file(
         tmp_path / "pyproject.toml",
-        "[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\n",
+        "[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\n",
     )
     result = guard.verify_package_boundary(
         package_dir=str(pkg), pyproject_path=str(tmp_path / "pyproject.toml"),
@@ -114,8 +114,10 @@ def test_missing_pyproject_fails_closed(guard, tmp_path):
     assert any(f.finding_type == "missing_control" for f in result.findings)
 
 
-def test_non_hatch_no_wheel_config_skips_gracefully(guard, tmp_path):
-    """No [build-system] defaults to setuptools (PEP 517) — skip hatch checks in v1."""
+def test_missing_backend_blocked(guard, tmp_path):
+    """Missing/unmodeled backend cannot be verified -> BLOCKED (fail-closed
+    per the backend allowlist: pip would still build it with setuptools,
+    whose rules are not modeled)."""
     pkg = tmp_path / "mypkg"
     pkg.mkdir(parents=True)
     _write_file(pkg / "__init__.py")
@@ -127,7 +129,26 @@ def test_non_hatch_no_wheel_config_skips_gracefully(guard, tmp_path):
         package_dir=str(pkg), pyproject_path=str(tmp_path / "pyproject.toml"),
         package_name="mypkg",
     )
-    assert result.is_safe is True
+    assert result.is_safe is False
+    assert any(f.finding_type == "unknown_boundary" for f in result.findings)
+
+
+def test_unmodeled_similar_backend_blocked(guard, tmp_path):
+    """Prefix lookalikes like hatchling.malicious must not pass the exact
+    allowlist (CodeRabbit)."""
+    pkg = tmp_path / "mypkg"
+    pkg.mkdir(parents=True)
+    _write_file(pkg / "__init__.py")
+    _write_file(
+        tmp_path / "pyproject.toml",
+        "[build-system]\nbuild-backend = 'hatchling.malicious'\nrequires = ['whatever']\n",
+    )
+    result = guard.verify_package_boundary(
+        package_dir=str(pkg), pyproject_path=str(tmp_path / "pyproject.toml"),
+        package_name="mypkg",
+    )
+    assert result.is_safe is False
+    assert any(f.finding_type == "unknown_boundary" for f in result.findings)
 
 
 def test_pyproject_missing_package_in_packages(guard, tmp_path):
@@ -136,7 +157,7 @@ def test_pyproject_missing_package_in_packages(guard, tmp_path):
     _write_file(pkg / "__init__.py")
     _write_file(
         tmp_path / "pyproject.toml",
-        "[tool.hatch.build.targets.wheel]\npackages = ['otherpkg']\n",
+        "[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['otherpkg']\n",
     )
     result = guard.verify_package_boundary(
         package_dir=str(pkg), pyproject_path=str(tmp_path / "pyproject.toml"),
@@ -162,7 +183,7 @@ def test_clean_package_passes(guard, tmp_path):
     _write_file(pkg / "module.py")
     _write_file(
         tmp_path / "pyproject.toml",
-        "[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\n",
+        "[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\n",
     )
     result = guard.verify_package_boundary(
         package_dir=str(pkg), pyproject_path=str(tmp_path / "pyproject.toml"),
@@ -270,7 +291,7 @@ def test_wheel_include_option_blocks(guard, tmp_path):
     _write_file(pkg / "__init__.py")
     _write_file(
         tmp_path / "pyproject.toml",
-        "[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\ninclude = ['extra/*']\n",
+        "[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\ninclude = ['extra/*']\n",
     )
     result = guard.verify_package_boundary(
         package_dir=str(pkg), pyproject_path=str(tmp_path / "pyproject.toml"),
@@ -286,7 +307,7 @@ def test_wheel_artifacts_option_blocks(guard, tmp_path):
     _write_file(pkg / "__init__.py")
     _write_file(
         tmp_path / "pyproject.toml",
-        "[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\nartifacts = ['generated/*']\n",
+        "[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\nartifacts = ['generated/*']\n",
     )
     result = guard.verify_package_boundary(
         package_dir=str(pkg), pyproject_path=str(tmp_path / "pyproject.toml"),
@@ -302,7 +323,7 @@ def test_wheel_force_include_option_blocks(guard, tmp_path):
     _write_file(pkg / "__init__.py")
     _write_file(
         tmp_path / "pyproject.toml",
-        "[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\nforce-include = {'/etc/config' = 'config'}\n",
+        "[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\nforce-include = {'/etc/config' = 'config'}\n",
     )
     result = guard.verify_package_boundary(
         package_dir=str(pkg), pyproject_path=str(tmp_path / "pyproject.toml"),
@@ -318,7 +339,7 @@ def test_wheel_only_packages_allows_widening_opts(guard, tmp_path):
     _write_file(pkg / "__init__.py")
     _write_file(
         tmp_path / "pyproject.toml",
-        "[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\ninclude = ['extra/*']\nonly-packages = true\n",
+        "[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\ninclude = ['extra/*']\nonly-packages = true\n",
     )
     result = guard.verify_package_boundary(
         package_dir=str(pkg), pyproject_path=str(tmp_path / "pyproject.toml"),
@@ -342,7 +363,7 @@ def test_only_include_with_path_entries_outside_blocked(guard, tmp_path):
     _write_file(pkg / "__init__.py")
     _write_file(
         tmp_path / "pyproject.toml",
-        "[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\nonly-include = ['src/mypkg', 'mypkg/extra']\n",
+        "[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\nonly-include = ['src/mypkg', 'mypkg/extra']\n",
     )
     result = guard.verify_package_boundary(
         package_dir=str(pkg), pyproject_path=str(tmp_path / "pyproject.toml"),
@@ -360,7 +381,7 @@ def test_only_include_within_boundary_passes(guard, tmp_path):
     _write_file(pkg / "sub" / "extra.py")
     _write_file(
         tmp_path / "pyproject.toml",
-        "[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\nonly-include = ['mypkg', 'mypkg/sub']\n",
+        "[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\nonly-include = ['mypkg', 'mypkg/sub']\n",
     )
     result = guard.verify_package_boundary(
         package_dir=str(pkg), pyproject_path=str(tmp_path / "pyproject.toml"),
@@ -375,7 +396,7 @@ def test_default_pyproject_path_resolved_from_package_dir(guard, tmp_path):
     _write_file(pkg / "__init__.py")
     _write_file(
         tmp_path / "pyproject.toml",
-        "[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\n",
+        "[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\n",
     )
     result = guard.verify_package_boundary(
         package_dir=str(pkg), package_name="mypkg",

--- a/tests/test_guard_diagnostics.py
+++ b/tests/test_guard_diagnostics.py
@@ -1,6 +1,9 @@
+from pathlib import Path
+
 import pydantic
 import pytest
 from qwed_infra.diagnostics import InfraDiagnosticStatus
+from qwed_infra.guards.artifact_boundary_guard import ArtifactBoundaryGuard
 from qwed_infra.guards.iam_guard import IamGuard, VerificationResult
 from qwed_infra.guards.network_guard import ComputedPath, NetworkGuard
 from qwed_infra.guards.cost_guard import CostEstimate, CostGuard
@@ -772,6 +775,137 @@ class TestCostGuardToVerificationContext:
             guard.to_verification_context(
                 resources,
                 "100.00",
+                formal_statement=formal_statement,
+                attestation_token=attestation_token,
+            )
+
+
+class TestArtifactBoundaryGuardToVerificationContext:
+    FORMAL_STATEMENT = "Package boundary is safe to publish"
+
+    @staticmethod
+    def _attestation_token():
+        return "attestation-fixture-opaque"
+
+    @staticmethod
+    def _write_file(path: Path, content: str = ""):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        return path
+
+    def _safe_package(self, tmp_path: Path):
+        pkg = tmp_path / "mypkg"
+        pkg.mkdir(parents=True)
+        self._write_file(pkg / "__init__.py")
+        self._write_file(
+            tmp_path / "pyproject.toml",
+            "[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\n",
+        )
+        return pkg, str(tmp_path / "pyproject.toml")
+
+    def test_safe_package_with_attestation(self, tmp_path):
+        guard = ArtifactBoundaryGuard()
+        pkg, pyproject = self._safe_package(tmp_path)
+        vc = guard.to_verification_context(
+            package_dir=str(pkg),
+            pyproject_path=pyproject,
+            package_name="mypkg",
+            formal_statement=self.FORMAL_STATEMENT,
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.VERIFIED
+        assert vc.context.decision.admission == Admission.ADMIT
+        assert vc.context.proof.verifier == "ArtifactBoundaryGuard"
+        assert vc.context.evidence.proof_ref.startswith("sha256:")
+        assert len(vc.context.evidence.proof_ref) == 71
+        doc_dict = vc.to_dict()
+        assert is_valid_document(doc_dict) is True
+        assert resolve_document_proof_ref(doc_dict) is True
+
+    def test_safe_package_without_attestation_demoted(self, tmp_path):
+        guard = ArtifactBoundaryGuard()
+        pkg, pyproject = self._safe_package(tmp_path)
+        vc = guard.to_verification_context(
+            package_dir=str(pkg),
+            pyproject_path=pyproject,
+            package_name="mypkg",
+            formal_statement=self.FORMAL_STATEMENT,
+        )
+        assert vc.verdict == Verdict.UNVERIFIABLE
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        assert is_valid_document(vc.to_dict()) is True
+
+    def test_unsafe_package_never_admissible(self, tmp_path):
+        guard = ArtifactBoundaryGuard()
+        pkg = tmp_path / "mypkg"
+        pkg.mkdir(parents=True)
+        self._write_file(pkg / ".env", "API_KEY=abc123")
+        vc = guard.to_verification_context(
+            package_dir=str(pkg),
+            formal_statement=self.FORMAL_STATEMENT,
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        assert is_valid_document(vc.to_dict()) is True
+        payload = vc.context.evidence.payload
+        assert payload["developer_fields"]["is_safe"] is False
+        finding_types = [f["finding_type"] for f in payload["developer_fields"]["findings"]]
+        assert "disclosure_risk" in finding_types
+
+    def test_missing_directory_fails_closed(self, tmp_path):
+        guard = ArtifactBoundaryGuard()
+        vc = guard.to_verification_context(
+            package_dir=str(tmp_path / "nonexistent_dir"),
+            pyproject_path=str(tmp_path / "nonexistent.toml"),
+            formal_statement=self.FORMAL_STATEMENT,
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        assert is_valid_document(vc.to_dict()) is True
+        assert vc.context.evidence.payload["developer_fields"]["is_safe"] is False
+
+    def test_evidence_preserves_diagnostic_fields(self, tmp_path):
+        guard = ArtifactBoundaryGuard()
+        pkg, pyproject = self._safe_package(tmp_path)
+        vc = guard.to_verification_context(
+            package_dir=str(pkg),
+            pyproject_path=pyproject,
+            package_name="mypkg",
+            formal_statement=self.FORMAL_STATEMENT,
+            attestation_token=self._attestation_token(),
+        )
+        payload = vc.context.evidence.payload
+        assert payload["developer_fields"]["constraint_id"] == "artifact_boundary_guard.verify_package_boundary"
+        assert payload["developer_fields"]["is_safe"] is True
+        assert payload["developer_fields"]["rule_ids"] == ("ARTIFACT_BOUNDARY_VERIFIED",)
+        assert payload["developer_fields"]["file_count"] >= 1
+        assert payload["developer_fields"]["audit_trace"]["rule_id"] == "ARTIFACT_BOUNDARY_VERIFIED"
+
+    @pytest.mark.parametrize(
+        "formal_statement",
+        [
+            "",
+            "   \n\t ",
+            123,
+            None,
+        ],
+    )
+    def test_invalid_formal_statement_rejected(self, tmp_path, formal_statement):
+        from qwed_infra.verification_context import VerificationContextValidationError
+
+        guard = ArtifactBoundaryGuard()
+        pkg, pyproject = self._safe_package(tmp_path)
+        attestation_token = self._attestation_token()
+        with pytest.raises(VerificationContextValidationError):
+            guard.to_verification_context(
+                package_dir=str(pkg),
+                pyproject_path=pyproject,
+                package_name="mypkg",
                 formal_statement=formal_statement,
                 attestation_token=attestation_token,
             )

--- a/tests/test_guard_diagnostics.py
+++ b/tests/test_guard_diagnostics.py
@@ -1106,6 +1106,58 @@ class TestArtifactBoundaryGuardToVerificationContext:
         finding_types = [f["finding_type"] for f in payload["developer_fields"]["findings"]]
         assert "missing_control" in finding_types
 
+    def test_non_string_build_backend_blocked(self, tmp_path):
+        """A build-backend that isn't a string (array/table) is a structured failure."""
+        guard = ArtifactBoundaryGuard()
+        pkg = tmp_path / "mypkg"
+        pkg.mkdir(parents=True)
+        self._write_file(pkg / "__init__.py")
+        self._write_file(
+            tmp_path / "pyproject.toml",
+            "[build-system]\nbuild-backend = ['hatchling.build']\nrequires = ['hatchling']\n",
+        )
+        vc = guard.to_verification_context(
+            package_dir=str(pkg),
+            pyproject_path=str(tmp_path / "pyproject.toml"),
+            formal_statement=self.FORMAL_STATEMENT,
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        payload = vc.context.evidence.payload
+        finding_types = [f["finding_type"] for f in payload["developer_fields"]["findings"]]
+        assert "unknown_boundary" in finding_types
+
+    def test_external_directory_symlink_blocked(self, tmp_path):
+        """A directory symlink pointing outside the scanned package fails closed."""
+        import os
+
+        guard = ArtifactBoundaryGuard()
+        pkg = tmp_path / "mypkg"
+        pkg.mkdir(parents=True)
+        self._write_file(pkg / "__init__.py")
+        external_dir = tmp_path / "external"
+        external_dir.mkdir()
+        self._write_file(external_dir / "leaked.py", "# secret")
+        try:
+            os.symlink(external_dir, pkg / "subdir", target_is_directory=True)
+        except OSError as exc:
+            pytest.skip(f"symlinks not permitted on this platform: {exc}")
+        self._write_file(
+            tmp_path / "pyproject.toml",
+            "[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\n",
+        )
+        vc = guard.to_verification_context(
+            package_dir=str(pkg),
+            pyproject_path=str(tmp_path / "pyproject.toml"),
+            formal_statement=self.FORMAL_STATEMENT,
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+
     def test_symlink_to_outside_blocked(self, tmp_path):
         """A file that's a symlink to a path outside the package resolves
         outside the scanned boundary -> BLOCKED."""

--- a/tests/test_guard_diagnostics.py
+++ b/tests/test_guard_diagnostics.py
@@ -1082,6 +1082,30 @@ class TestArtifactBoundaryGuardToVerificationContext:
         finding_types = [f["finding_type"] for f in payload["developer_fields"]["findings"]]
         assert "unknown_boundary" in finding_types
 
+    def test_hatchling_without_wheel_target_blocked(self, tmp_path):
+        """hatchling.build with no [tool.hatch.build.targets.wheel] section is denied —
+        the wheel boundary is inferred by the backend, not the declared scan."""
+        guard = ArtifactBoundaryGuard()
+        pkg = tmp_path / "mypkg"
+        pkg.mkdir(parents=True)
+        self._write_file(pkg / "__init__.py")
+        self._write_file(
+            tmp_path / "pyproject.toml",
+            "[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[project]\nname = 'mypkg'\nversion = '0.1.0'\n",
+        )
+        vc = guard.to_verification_context(
+            package_dir=str(pkg),
+            pyproject_path=str(tmp_path / "pyproject.toml"),
+            formal_statement=self.FORMAL_STATEMENT,
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        payload = vc.context.evidence.payload
+        finding_types = [f["finding_type"] for f in payload["developer_fields"]["findings"]]
+        assert "missing_control" in finding_types
+
     def test_symlink_to_outside_blocked(self, tmp_path):
         """A file that's a symlink to a path outside the package resolves
         outside the scanned boundary -> BLOCKED."""
@@ -1143,24 +1167,35 @@ class TestArtifactBoundaryGuardToVerificationContext:
         assert "unknown_boundary" in finding_types
 
     def test_wheel_entry_symlink_loop_blocked(self, tmp_path):
-        """A wheel entry that resolves through a symlink loop must not crash or ADMIT."""
+        """A wheel entry that resolves through a symlink loop must not crash or ADMIT.
+
+        The loop lives outside the scanned package file collection, so the
+        rejection must come from the wheel-entry path, not _collect_package_files.
+        """
         import os
 
         guard = ArtifactBoundaryGuard()
-        pkg = tmp_path / "mypkg"
-        pkg.mkdir(parents=True)
-        self._write_file(pkg / "__init__.py")
+        # The loop is a sibling of the scanned package under pkg_root, so the
+        # scanner cannot collect it; only wheel entry resolution traverses it.
+        pkg_root = tmp_path / "pkg_root"
+        pkg_root.mkdir()
+        scanned_pkg = pkg_root / "mypkg"
+        scanned_pkg.mkdir()
+        self._write_file(scanned_pkg / "__init__.py")
+
+        loop_dir = pkg_root / "somedir"
+        loop_dir.mkdir()
         try:
-            os.symlink("loop", pkg / "loop")
+            os.symlink("mypkg", loop_dir / "mypkg")
         except OSError as exc:
             pytest.skip(f"symlinks not permitted on this platform: {exc}")
         self._write_file(
-            tmp_path / "pyproject.toml",
-            "[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\nonly-include = ['mypkg/loop']\n",
+            pkg_root / "pyproject.toml",
+            "[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\nonly-include = ['somedir/mypkg/__init__.py']\n",
         )
         vc = guard.to_verification_context(
-            package_dir=str(pkg),
-            pyproject_path=str(tmp_path / "pyproject.toml"),
+            package_dir=str(scanned_pkg),
+            pyproject_path=str(pkg_root / "pyproject.toml"),
             formal_statement=self.FORMAL_STATEMENT,
             attestation_token=self._attestation_token(),
         )

--- a/tests/test_guard_diagnostics.py
+++ b/tests/test_guard_diagnostics.py
@@ -799,7 +799,7 @@ class TestArtifactBoundaryGuardToVerificationContext:
         self._write_file(pkg / "__init__.py")
         self._write_file(
             tmp_path / "pyproject.toml",
-            "[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\n",
+            "[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\n",
         )
         return pkg, str(tmp_path / "pyproject.toml")
 
@@ -898,7 +898,7 @@ class TestArtifactBoundaryGuardToVerificationContext:
             pyproj = tmp_path / f"{name}_pyproject.toml"
             self._write_file(
                 pyproj,
-                f"[tool.hatch.build.targets.wheel]\npackages = ['{name}']\n",
+                f"[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['{name}']\n",
             )
             return guard.to_verification_context(
                 package_dir=str(pkg),
@@ -924,7 +924,7 @@ class TestArtifactBoundaryGuardToVerificationContext:
         pyproject = tmp_path / "pyproject.toml"
         self._write_file(
             pyproject,
-            "[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\n",
+            "[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\n",
         )
         vc_v1 = guard.to_verification_context(
             package_dir=str(pkg),
@@ -988,7 +988,7 @@ class TestArtifactBoundaryGuardToVerificationContext:
         # wheel packages reference a package that is NOT the scanned directory
         self._write_file(
             tmp_path / "pyproject.toml",
-            "[tool.hatch.build.targets.wheel]\npackages = ['otherpkg']\n",
+            "[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['otherpkg']\n",
         )
         vc = guard.to_verification_context(
             package_dir=str(pkg),
@@ -1020,7 +1020,7 @@ class TestArtifactBoundaryGuardToVerificationContext:
         pkgs_repr = ", ".join(f"'{p}'" for p in packages)
         self._write_file(
             tmp_path / "pyproject.toml",
-            f"[tool.hatch.build.targets.wheel]\npackages = [{pkgs_repr}]\n",
+            f"[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = [{pkgs_repr}]\n",
         )
         vc = guard.to_verification_context(
             package_dir=str(pkg),
@@ -1047,7 +1047,7 @@ class TestArtifactBoundaryGuardToVerificationContext:
         oi_repr = ", ".join(f"'{p}'" for p in only_include)
         self._write_file(
             tmp_path / "pyproject.toml",
-            f"[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\nonly-include = [{oi_repr}]\n",
+            f"[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\nonly-include = [{oi_repr}]\n",
         )
         vc = guard.to_verification_context(
             package_dir=str(pkg),
@@ -1081,6 +1081,121 @@ class TestArtifactBoundaryGuardToVerificationContext:
         payload = vc.context.evidence.payload
         finding_types = [f["finding_type"] for f in payload["developer_fields"]["findings"]]
         assert "unknown_boundary" in finding_types
+
+    def test_symlink_to_outside_blocked(self, tmp_path):
+        """A file that's a symlink to a path outside the package resolves
+        outside the scanned boundary -> BLOCKED."""
+        import os
+
+        guard = ArtifactBoundaryGuard()
+        pkg = tmp_path / "mypkg"
+        pkg.mkdir(parents=True)
+        external = tmp_path / ".env"
+        self._write_file(external, "SECRET=value")
+        # External symlink inside the package
+        link = pkg / "module.py"
+        try:
+            os.symlink(external, link)
+        except OSError as exc:
+            pytest.skip(f"symlinks not permitted on this platform: {exc}")
+        self._write_file(pkg / "__init__.py")
+        self._write_file(
+            tmp_path / "pyproject.toml",
+            "[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\n",
+        )
+        vc = guard.to_verification_context(
+            package_dir=str(pkg),
+            pyproject_path=str(tmp_path / "pyproject.toml"),
+            formal_statement=self.FORMAL_STATEMENT,
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+
+    def test_broken_symlink_reported(self, tmp_path):
+        """Broken symlinks are surfaced as findings, not silently omitted."""
+        import os
+
+        guard = ArtifactBoundaryGuard()
+        pkg = tmp_path / "mypkg"
+        pkg.mkdir(parents=True)
+        self._write_file(pkg / "__init__.py")
+        try:
+            os.symlink(tmp_path / "nonexistent-target", pkg / "dangling.py")
+        except OSError as exc:
+            pytest.skip(f"symlinks not permitted on this platform: {exc}")
+        self._write_file(
+            tmp_path / "pyproject.toml",
+            "[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\n",
+        )
+        vc = guard.to_verification_context(
+            package_dir=str(pkg),
+            pyproject_path=str(tmp_path / "pyproject.toml"),
+            formal_statement=self.FORMAL_STATEMENT,
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        payload = vc.context.evidence.payload
+        finding_types = [f["finding_type"] for f in payload["developer_fields"]["findings"]]
+        assert "unknown_boundary" in finding_types
+
+    def test_wheel_entry_symlink_loop_blocked(self, tmp_path):
+        """A wheel entry that resolves through a symlink loop must not crash or ADMIT."""
+        import os
+
+        guard = ArtifactBoundaryGuard()
+        pkg = tmp_path / "mypkg"
+        pkg.mkdir(parents=True)
+        self._write_file(pkg / "__init__.py")
+        try:
+            os.symlink("loop", pkg / "loop")
+        except OSError as exc:
+            pytest.skip(f"symlinks not permitted on this platform: {exc}")
+        self._write_file(
+            tmp_path / "pyproject.toml",
+            "[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\nonly-include = ['mypkg/loop']\n",
+        )
+        vc = guard.to_verification_context(
+            package_dir=str(pkg),
+            pyproject_path=str(tmp_path / "pyproject.toml"),
+            formal_statement=self.FORMAL_STATEMENT,
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+
+    def test_distinct_scan_and_rules_dirs_share_basename_blocked(self, tmp_path):
+        """If the scanned dir and the pyproject root are different roots, validation
+        and evidence must target the scanned package directory (CodeRabbit)."""
+        guard = ArtifactBoundaryGuard()
+        scanned_root = tmp_path / "scan_root"
+        scanned_root.mkdir()
+        rules_root = tmp_path / "rules_root"
+        rules_root.mkdir()
+        # Same package basename, different roots
+        scanned_dir = scanned_root / "mypkg"
+        scanned_dir.mkdir(parents=True)
+        self._write_file(scanned_dir / "__init__.py")
+        self._write_file(
+            rules_root / "pyproject.toml",
+            "[build-system]\nrequires = ['hatchling']\nbuild-backend = 'hatchling.build'\n\n[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\n",
+        )
+        vc = guard.to_verification_context(
+            package_dir=str(scanned_dir),
+            pyproject_path=str(rules_root / "pyproject.toml"),
+            formal_statement=self.FORMAL_STATEMENT,
+            attestation_token=self._attestation_token(),
+        )
+        # The scanned root is scanned_root, but the pyproject lives under rules_root.
+        # boundary_dir must be the scanned package path (not the pyproject parent),
+        # so wheel resolution cannot silently target rules_root/mypkg.
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
 
     @pytest.mark.parametrize(
         "formal_statement",

--- a/tests/test_guard_diagnostics.py
+++ b/tests/test_guard_diagnostics.py
@@ -912,6 +912,38 @@ class TestArtifactBoundaryGuardToVerificationContext:
         vc2 = make_verified_vc("pkg_two", "beta.py")
         assert vc1.context.evidence.proof_ref != vc2.context.evidence.proof_ref
 
+    def test_content_change_changes_proof_ref(self, tmp_path):
+        """Changing a file at the same path must change the proof_ref.
+
+        Without this, the proof would only bind to paths/count, not contents.
+        """
+        guard = ArtifactBoundaryGuard()
+        pkg = tmp_path / "mypkg"
+        pkg.mkdir(parents=True)
+        self._write_file(pkg / "module.py", "content-v1")
+        pyproject = tmp_path / "pyproject.toml"
+        self._write_file(
+            pyproject,
+            "[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\n",
+        )
+        vc_v1 = guard.to_verification_context(
+            package_dir=str(pkg),
+            pyproject_path=str(pyproject),
+            formal_statement=self.FORMAL_STATEMENT,
+            attestation_token=self._attestation_token(),
+        )
+        assert vc_v1.verdict == Verdict.VERIFIED
+        # Overwrite the same path with different content -> content_manifest changes
+        self._write_file(pkg / "module.py", "content-v2")
+        vc_v2 = guard.to_verification_context(
+            package_dir=str(pkg),
+            pyproject_path=str(pyproject),
+            formal_statement=self.FORMAL_STATEMENT,
+            attestation_token=self._attestation_token(),
+        )
+        assert vc_v2.verdict == Verdict.VERIFIED
+        assert vc_v1.context.evidence.proof_ref != vc_v2.context.evidence.proof_ref
+
     def test_none_package_dir_blocked(self):
         guard = ArtifactBoundaryGuard()
         vc = guard.to_verification_context(
@@ -971,6 +1003,84 @@ class TestArtifactBoundaryGuardToVerificationContext:
         assert payload["developer_fields"]["is_safe"] is False
         finding_types = [f["finding_type"] for f in payload["developer_fields"]["findings"]]
         assert "missing_control" in finding_types
+
+    @pytest.mark.parametrize(
+        "packages",
+        [
+            ["/outside/mypkg"],
+            ["mypkg/../../outside"],
+        ],
+    )
+    def test_wheel_absolute_or_traversal_packages_blocked(self, tmp_path, packages):
+        """Reject boundary violations that pass the naive 'name in parts' check."""
+        guard = ArtifactBoundaryGuard()
+        pkg = tmp_path / "mypkg"
+        pkg.mkdir(parents=True)
+        self._write_file(pkg / "__init__.py")
+        pkgs_repr = ", ".join(f"'{p}'" for p in packages)
+        self._write_file(
+            tmp_path / "pyproject.toml",
+            f"[tool.hatch.build.targets.wheel]\npackages = [{pkgs_repr}]\n",
+        )
+        vc = guard.to_verification_context(
+            package_dir=str(pkg),
+            pyproject_path=str(tmp_path / "pyproject.toml"),
+            formal_statement=self.FORMAL_STATEMENT,
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+
+    @pytest.mark.parametrize(
+        "only_include",
+        [
+            ["/etc/mypkg"],
+            ["mypkg/../../outside"],
+        ],
+    )
+    def test_wheel_absolute_or_traversal_only_include_blocked(self, tmp_path, only_include):
+        guard = ArtifactBoundaryGuard()
+        pkg = tmp_path / "mypkg"
+        pkg.mkdir(parents=True)
+        self._write_file(pkg / "__init__.py")
+        oi_repr = ", ".join(f"'{p}'" for p in only_include)
+        self._write_file(
+            tmp_path / "pyproject.toml",
+            f"[tool.hatch.build.targets.wheel]\npackages = ['mypkg']\nonly-include = [{oi_repr}]\n",
+        )
+        vc = guard.to_verification_context(
+            package_dir=str(pkg),
+            pyproject_path=str(tmp_path / "pyproject.toml"),
+            formal_statement=self.FORMAL_STATEMENT,
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+
+    def test_unsupported_build_backend_blocked(self, tmp_path):
+        """Non-hatchling explicit backends are denied: wheel boundary cannot be modeled."""
+        guard = ArtifactBoundaryGuard()
+        pkg = tmp_path / "mypkg"
+        pkg.mkdir(parents=True)
+        self._write_file(pkg / "__init__.py")
+        self._write_file(
+            tmp_path / "pyproject.toml",
+            "[build-system]\nbuild-backend = 'setuptools.build_meta'\nrequires = ['setuptools']\n\n[project]\nname = 'mypkg'\nversion = '0.1.0'\n",
+        )
+        vc = guard.to_verification_context(
+            package_dir=str(pkg),
+            pyproject_path=str(tmp_path / "pyproject.toml"),
+            formal_statement=self.FORMAL_STATEMENT,
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        payload = vc.context.evidence.payload
+        finding_types = [f["finding_type"] for f in payload["developer_fields"]["findings"]]
+        assert "unknown_boundary" in finding_types
 
     @pytest.mark.parametrize(
         "formal_statement",

--- a/tests/test_guard_diagnostics.py
+++ b/tests/test_guard_diagnostics.py
@@ -809,7 +809,6 @@ class TestArtifactBoundaryGuardToVerificationContext:
         vc = guard.to_verification_context(
             package_dir=str(pkg),
             pyproject_path=pyproject,
-            package_name="mypkg",
             formal_statement=self.FORMAL_STATEMENT,
             attestation_token=self._attestation_token(),
         )
@@ -828,7 +827,6 @@ class TestArtifactBoundaryGuardToVerificationContext:
         vc = guard.to_verification_context(
             package_dir=str(pkg),
             pyproject_path=pyproject,
-            package_name="mypkg",
             formal_statement=self.FORMAL_STATEMENT,
         )
         assert vc.verdict == Verdict.UNVERIFIABLE
@@ -875,7 +873,6 @@ class TestArtifactBoundaryGuardToVerificationContext:
         vc = guard.to_verification_context(
             package_dir=str(pkg),
             pyproject_path=pyproject,
-            package_name="mypkg",
             formal_statement=self.FORMAL_STATEMENT,
             attestation_token=self._attestation_token(),
         )
@@ -885,6 +882,95 @@ class TestArtifactBoundaryGuardToVerificationContext:
         assert payload["developer_fields"]["rule_ids"] == ("ARTIFACT_BOUNDARY_VERIFIED",)
         assert payload["developer_fields"]["file_count"] >= 1
         assert payload["developer_fields"]["audit_trace"]["rule_id"] == "ARTIFACT_BOUNDARY_VERIFIED"
+
+    def test_manifest_distinguishes_artifact_set(self, tmp_path):
+        """Two packages with the same file count should not yield the same proof_ref.
+
+        The manifest (file_paths) is hashed into the evidence, so changing the
+        paths changes the proof identity even when the count is unchanged.
+        """
+        guard = ArtifactBoundaryGuard()
+
+        def make_verified_vc(name: str, rel_file: str):
+            pkg = tmp_path / name
+            pkg.mkdir(parents=True)
+            self._write_file(pkg / rel_file, f"# {name} {rel_file}")
+            pyproj = tmp_path / f"{name}_pyproject.toml"
+            self._write_file(
+                pyproj,
+                f"[tool.hatch.build.targets.wheel]\npackages = ['{name}']\n",
+            )
+            return guard.to_verification_context(
+                package_dir=str(pkg),
+                pyproject_path=str(pyproj),
+                formal_statement=self.FORMAL_STATEMENT,
+                attestation_token=self._attestation_token(),
+            )
+
+        # Same count, different path -> different manifest -> different proof_ref
+        vc1 = make_verified_vc("pkg_one", "alpha.py")
+        vc2 = make_verified_vc("pkg_two", "beta.py")
+        assert vc1.context.evidence.proof_ref != vc2.context.evidence.proof_ref
+
+    def test_none_package_dir_blocked(self):
+        guard = ArtifactBoundaryGuard()
+        vc = guard.to_verification_context(
+            package_dir=None,
+            formal_statement=self.FORMAL_STATEMENT,
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        assert is_valid_document(vc.to_dict()) is True
+        assert vc.context.evidence.payload["developer_fields"]["is_safe"] is False
+
+    def test_malformed_pyproject_blocked(self, tmp_path):
+        guard = ArtifactBoundaryGuard()
+        pkg = tmp_path / "mypkg"
+        pkg.mkdir(parents=True)
+        self._write_file(pkg / "__init__.py")
+        # Scalar build-system -> structurally invalid for our traversal
+        self._write_file(tmp_path / "pyproject.toml", 'build-system = "hatchling"\n')
+        vc = guard.to_verification_context(
+            package_dir=str(pkg),
+            pyproject_path=str(tmp_path / "pyproject.toml"),
+            formal_statement=self.FORMAL_STATEMENT,
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        payload = vc.context.evidence.payload
+        assert payload["developer_fields"]["is_safe"] is False
+        finding_types = [f["finding_type"] for f in payload["developer_fields"]["findings"]]
+        assert "unknown_boundary" in finding_types
+
+    def test_wheel_packages_outside_checked_directory_blocked(self, tmp_path):
+        """Identity binding: scanning 'mypkg' while wheel config lists another package
+        must be BLOCKED (the checked directory's files cannot be confounded)."""
+        guard = ArtifactBoundaryGuard()
+        pkg = tmp_path / "mypkg"
+        pkg.mkdir(parents=True)
+        self._write_file(pkg / "__init__.py")
+        # wheel packages reference a package that is NOT the scanned directory
+        self._write_file(
+            tmp_path / "pyproject.toml",
+            "[tool.hatch.build.targets.wheel]\npackages = ['otherpkg']\n",
+        )
+        vc = guard.to_verification_context(
+            package_dir=str(pkg),
+            pyproject_path=str(tmp_path / "pyproject.toml"),
+            formal_statement=self.FORMAL_STATEMENT,
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        payload = vc.context.evidence.payload
+        assert payload["developer_fields"]["is_safe"] is False
+        finding_types = [f["finding_type"] for f in payload["developer_fields"]["findings"]]
+        assert "missing_control" in finding_types
 
     @pytest.mark.parametrize(
         "formal_statement",
@@ -905,8 +991,7 @@ class TestArtifactBoundaryGuardToVerificationContext:
             guard.to_verification_context(
                 package_dir=str(pkg),
                 pyproject_path=pyproject,
-                package_name="mypkg",
-                formal_statement=formal_statement,
+                    formal_statement=formal_statement,
                 attestation_token=attestation_token,
             )
 
@@ -942,3 +1027,4 @@ class TestPydanticExtraForbid:
                 reason="ok",
                 extra="bad",
             )
+


### PR DESCRIPTION
## **User description**
## Summary

Closes **#41** — adds `ArtifactBoundaryGuard.to_verification_context()` producing a Verification Context v1.0 document via the shared bridge, following the guard-computes-internally pattern established by #38 (IamGuard), #39 (NetworkGuard), and #40 (CostGuard). This is the last guard in the tracker #36 set.

## Security pattern

The guard **performs the computation itself** against the real filesystem — no result object is accepted, so a caller cannot mint a `VERIFIED`/`ADMIT` document with a forged `ArtifactBoundaryResult`:

- `ArtifactBoundaryGuard.to_verification_context(package_dir="qwed_infra", pyproject_path=None, package_name="qwed_infra", *, formal_statement, attestation_token=None)` runs `verify_package_boundary()` internally, then `to_diagnostic()`, then the shared bridge.

Fail-closed behavior:
- Safe package + non-empty attestation → `VERIFIED`/`ADMIT` with document-bound `proof_ref`
- Safe package without attestation → `UNVERIFIABLE`/`DENY`
- Unsafe package (secrets/disclosure/debug findings) or missing directory → `BLOCKED`/`DENY` with null `proof_ref` (never ADMIT), even with an attestation
- Provenance gate retained as defense-in-depth: only a VERIFIED diagnostic carrying ArtifactBoundaryGuard provenance (`constraint_id`) and an explicit `is_safe=True` outcome is admitted

## Tests (`tests/test_guard_diagnostics.py`)

New `TestArtifactBoundaryGuardToVerificationContext` (6 tests / 9 cases):
- Safe package with/without attestation (VERIFIED/ADMIT vs UNVERIFIABLE/DENY)
- Unsafe package (`.env` disclosure_risk) fail-closed (`BLOCKED`/`DENY`, never ADMIT), findings preserved
- Missing directory fails closed (`unknown_boundary`/`BLOCKED`)
- Evidence preserves `constraint_id`/`is_safe`/`rule_ids`/`file_count`/audit trace
- Invalid `formal_statement` boundaries (empty / whitespace-only / non-string) rejected

## Verification

- Full suite: **433 passed** (424 baseline + 9 new)
- Coverage: **93%** overall (artifact_boundary_guard.py 89%; the remaining lines are pre-existing `_check_build_config`/toml-fallback paths not exercised here)
- `ruff` clean; `scripts/check_boundary.py` passes


___

## **CodeAnt-AI Description**
Add verification documents for package boundary checks

### What Changed
- Package boundary checks can now produce a Verification Context document based on the actual package contents
- Safe packages are admitted only when an attestation is provided; otherwise they remain unverifiable and are denied
- Packages containing exposed secrets or missing directories are blocked and denied, with findings retained and no proof reference
- Verification evidence includes the boundary safety result, findings, file count, rules, and audit details
- Invalid or empty formal statements are rejected

### Impact
`✅ Safer package publishing`
`✅ No admission without package attestation`
`✅ Clearer evidence for boundary violations`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Verification results now include sorted package-file manifests and clearer diagnostic evidence.
  - Enforces package boundaries during verification and supports formal statements, verifier identity, and optional attestation tokens.

- **Bug Fixes**
  - Rejects broken, escaping, looping, and out-of-bound symlinks.
  - Requires an explicitly supported Hatchling build configuration, including a valid wheel section.
  - Missing, malformed, or unsupported configuration now fails closed with clear findings.
  - Improves wheel-entry resolution and preserves diagnostics during package verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->