### PR TITLE
fix: fail-closed on malformed inputs in NetworkGuard.to_verification_context() (#49)

### DIFF
--- a/qwed_infra/guards/network_guard.py
+++ b/qwed_infra/guards/network_guard.py
@@ -289,13 +289,27 @@ class NetworkGuard:
         """Run the reachability check and map the result to a VC v1.0 document.
 
         The guard performs the computation itself via verify_reachability(),
-        so a caller cannot inject a result object of any kind. The
-        provenance gate remains as defense-in-depth: only a VERIFIED
+        so a caller cannot inject a result object of any kind. Malformed
+        inputs (non-dict resources, missing subnet "id" keys, etc.) map to a
+        fail-closed BLOCKED diagnostic rather than propagating an exception.
+        The provenance gate remains as defense-in-depth: only a VERIFIED
         diagnostic carrying NetworkGuard provenance and an explicit
         reachable=True outcome is admitted; anything else is BLOCKED.
         """
-        result = self.verify_reachability(resources, source, destination, port)
-        diagnostic = self.to_diagnostic(result)
+        try:
+            result = self.verify_reachability(resources, source, destination, port)
+        except (TypeError, ValueError, AttributeError, KeyError):
+            diagnostic = InfraDiagnosticResult.blocked(
+                agent_message="Network reachability could not be verified",
+                developer_fields={
+                    "constraint_id": _NETWORK_CONSTRAINT_ID,
+                    "reachable": False,
+                    "reason": "Invalid inputs to the reachability check — fail closed",
+                    "audit_trace": build_trace(NETWORK_UNSUPPORTED_TOPOLOGY, "INVALID_INPUT"),
+                },
+            )
+        else:
+            diagnostic = self.to_diagnostic(result)
         decision_status = None
         if diagnostic.status is InfraDiagnosticStatus.VERIFIED and not (
             diagnostic.developer_fields.get("constraint_id") == _NETWORK_CONSTRAINT_ID

--- a/tests/test_guard_diagnostics.py
+++ b/tests/test_guard_diagnostics.py
@@ -454,6 +454,54 @@ class TestNetworkGuardToVerificationContext:
         assert serialized == ["internet", "subnet-a"]
 
     @pytest.mark.parametrize(
+        "resources",
+        [
+            None,
+            "not-a-dict",
+            42,
+            {"subnets": None},
+            {"subnets": "not-a-list"},
+            {"subnets": [{"no-id": "subnet-a"}]},
+            {"subnets": [{"id": "subnet-a"}], "route_tables": None},
+        ],
+    )
+    def test_malformed_resources_blocked(self, resources):
+        """Fail-closed on malformed topology inputs (no raised exception)."""
+        guard = NetworkGuard()
+        vc = guard.to_verification_context(
+            resources,
+            "internet",
+            "subnet-a",
+            80,
+            formal_statement="Traffic from internet to subnet-a on port 80 is safe",
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        assert is_valid_document(vc.to_dict()) is True
+        payload = vc.context.evidence.payload
+        assert payload["developer_fields"]["reachable"] is False
+
+    def test_invalid_input_audit_trace(self):
+        """Malformed inputs produce an INVALID_INPUT audit outcome."""
+        guard = NetworkGuard()
+        vc = guard.to_verification_context(
+            None,
+            "internet",
+            "subnet-a",
+            80,
+            formal_statement="Traffic from internet to subnet-a on port 80 is safe",
+            attestation_token=self._attestation_token(),
+        )
+        assert vc.verdict == Verdict.BLOCKED
+        assert vc.context.decision.admission == Admission.DENY
+        assert vc.context.evidence.proof_ref is None
+        payload = vc.context.evidence.payload
+        assert payload["developer_fields"]["audit_trace"]["outcome"] == "INVALID_INPUT"
+        assert payload["developer_fields"]["constraint_id"] == "network_guard.verify_reachability"
+
+    @pytest.mark.parametrize(
         "formal_statement",
         [
             "",


### PR DESCRIPTION
## **User description**
## Summary

Closes **#49** — hardens `NetworkGuard.to_verification_context()` to fail closed on malformed inputs, completing the same robustness fix CodeAnt requested for CostGuard in PR #48.

## The gap

`verify_reachability()` can raise uncaught exceptions when callers pass malformed resources:
- `AttributeError` — `resources=None` or any non-dict object (`.get()` on a str/int)
- `KeyError` — subnet entries missing `"id"` in `build_graph`
- `TypeError`/`ValueError` — non-iterable `subnets`/`route_tables`, wrong-shape values

The exception propagates out of the VC adapter, so the caller gets a crash instead of a fail-closed document. `IamGuard` was already fine (`verify_access` catches internally → UNVERIFIABLE); `CostGuard` was fixed in PR #48 (#40). `NetworkGuard` is the same gap.

## Fix

Wrap the `verify_reachability()` call in `to_verification_context()` and map `(TypeError, ValueError, AttributeError, KeyError)` to an `InfraDiagnosticResult.blocked` diagnostic with:

- `constraint_id: "network_guard.verify_reachability"`
- `reachable: False`
- `reason: "Invalid inputs to the reachability check — fail closed"`
- `audit_trace: build_trace(NETWORK_UNSUPPORTED_TOPOLOGY, "INVALID_INPUT")`

This flows through the normal bridge path → `BLOCKED`/`DENY` with null `proof_ref` (never ADMIT, even with an attestation token). Existing clean behavior is unchanged.

## Tests (`tests/test_guard_diagnostics.py`)

New regression coverage in `TestNetworkGuardToVerificationContext`:
- `test_malformed_resources_blocked` — 7 parametrized malformed-resource shapes (`None`, non-dict, missing subnet `id`, wrong-shape `subnets`/`route_tables`) → all `BLOCKED`/`DENY`, no `proof_ref`, valid document
- `test_invalid_input_audit_trace` — malformed input yields `INVALID_INPUT` audit outcome + NetworkGuard constraint_id

## Verification

- Full suite: **456 passed** (448 baseline + 8 new), 4 skipped (symlink cases on Windows)
- Coverage: ~92% overall (network_guard.py 89%)
- `ruff` clean; `scripts/check_boundary.py` passes


___

## **CodeAnt-AI Description**
Fail closed on malformed network reachability inputs

### What Changed
- Malformed network resources now produce a valid blocked verification result instead of raising an exception
- Invalid reachability inputs are denied even when an attestation token is provided
- Blocked results identify the invalid input and record an `INVALID_INPUT` audit outcome
- Added coverage for missing fields, incorrect resource types, and invalid subnet or route table shapes

### Impact
`✅ Fewer network verification crashes`
`✅ No admission from malformed topology data`
`✅ Clearer invalid-input audit records`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Malformed network resource inputs now fail safely with a blocked verdict instead of causing an error.
  * Invalid inputs are clearly reported as unreachable and marked with invalid-input audit details.
  * Valid network verification results continue to behave as expected.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->