### PR TITLE
docs: Verification Context v1.0 section + VC badge + CHANGELOG (#43)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### Fixed
 - Fail-closed on malformed inputs at every VC boundary: undecimal budgets, extreme Decimal values, non-string build backends, malformed topology/policy/package inputs, symlink escapes/loops, wheel entries outside the scanned boundary — all map to BLOCKED/DENY documents instead of exceptions or guessed approval (#48, #49/PR #51, #50)
 - ArtifactBoundaryGuard proof binding: content manifests (per-file sha256), package identity derived from the inspected directory, exact-match backend allowlist (#47 follow-ups in PR #50)
-- IAM verified-denial results demote to BLOCKED (never ADMIT); verified IAM denials preserve their diagnostic proof reference in the document evidence
+- IAM verified-denial results demote to BLOCKED (never ADMIT); the diagnostic's own proof hash is preserved inside the evidence payload (`diagnostic_proof_ref`), while the document-level `evidence.proof_ref` stays null for every DENY decision (fail-closed contract)
 
 ## [0.2.0] - 2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- Verification Context v1.0 across all four guards (tracker #36) — every guard now exposes `to_verification_context()`, producing a schema-valid, tamper-evident VC document (claim, verifier identity, `sha256`-bound evidence `proof_ref`, ADMIT/DENY admission):
+  - IamGuard (#38, PR #45), NetworkGuard (#39, PR #46), CostGuard (#40, PR #48), ArtifactBoundaryGuard (#41, PR #50)
+  - Shared bridge module `verification_context_bridge` (#37, PR #44): diagnostic → VC document conversion with fail-closed attestation policy and decision-status demotion
+  - Conformance suite `tests/test_vc_conformance.py` (#42, PR #52) — bridge + all guards + document validation + malformed-input fail-closed acceptance tests
+  - README: "Verification Context v1.0" section — why VC, usage examples, downstream integration guide; VC badge in the header
+
+### Changed
+- **BREAKING (pre-1.0, unreleased API):** guard adapters no longer accept pre-computed result objects. `to_verification_context()` takes **raw verification inputs** and runs the guard's own deterministic solver internally (`NetworkGuard.to_verification_context(resources, source, destination, port, ...)` / `IamGuard.to_verification_context(policy, action, resource, context, ...)` / `CostGuard.to_verification_context(resources, budget_monthly, ...)` / `ArtifactBoundaryGuard.to_verification_context(package_dir, ...)`) — a result-accepting signature is forgeable (a caller could fabricate a positive result and mint ADMIT), so it was removed before any release (PRs #45/#46/#48/#50)
+
+### Fixed
+- Fail-closed on malformed inputs at every VC boundary: undecimal budgets, extreme Decimal values, non-string build backends, malformed topology/policy/package inputs, symlink escapes/loops, wheel entries outside the scanned boundary — all map to BLOCKED/DENY documents instead of exceptions or guessed approval (#48, #49/PR #51, #50)
+- ArtifactBoundaryGuard proof binding: content manifests (per-file sha256), package identity derived from the inspected directory, exact-match backend allowlist (#47 follow-ups in PR #50)
+- IAM verified-denial results demote to BLOCKED (never ADMIT); verified IAM denials preserve their diagnostic proof reference in the document evidence
+
 ## [0.2.0] - 2026-07-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 > "Don't let AI hallucinate your cloud bill to $20,000."
 
 [![Verified by QWED](https://img.shields.io/badge/Verified_by-QWED-00C853?style=flat&logo=checkmarx)](https://github.com/QWED-AI/qwed-infra)
+[![Verification Context](https://img.shields.io/badge/VC-v1.0-6C3FC5?style=flat&logo=docusign)](https://github.com/QWED-AI/qwed-infra#verification-context-v10)
 [![PyPI](https://img.shields.io/pypi/v/qwed-infra?color=blue&logo=pypi&logoColor=white)](https://pypi.org/project/qwed-infra/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/)
@@ -185,6 +186,79 @@ if diagnostic.status.value == "BLOCKED":
 else:
     print("✅ Package boundary verified — safe to ship.")
 ```
+
+---
+
+## 🔏 Verification Context v1.0
+
+Every guard can emit a **Verification Context (VC) document** — a portable, machine-checkable trust artifact that records *what was verified, by whom, with what proof*, and *whether a downstream system should admit or deny*.
+
+### Why VC?
+
+A `True/False` return value is enough for one process — but CI/CD pipelines, release gates, and audit trails need **evidence that travels**:
+
+| Plain result | Verification Context |
+| :--- | :--- |
+| `result.allowed == False` | Signed-off document: claim, verifier identity+version, evidence hash (`proof_ref`), admission decision |
+| Lives only in your process log | JSON-serializable, schema-validated, tamper-evident (`sha256` bound to the evidence) |
+| No story when someone asks "who verified this?" | `proof.verifier`, `audit_trace`, and rule IDs answer it |
+
+The document is **fail-closed by construction**: anything that is not proven is `DENY` — `UNVERIFIABLE` and `BLOCKED` outcomes can never produce `ADMIT`.
+
+### Usage
+
+Each guard runs its own verification internally and returns a VC document. You pass raw inputs — never a pre-computed result object:
+
+```python
+from qwed_infra import NetworkGuard
+
+net = NetworkGuard()
+infra = {
+    "subnets": [{"id": "subnet-web", "security_groups": ["sg-web"]}],
+    "route_tables": [
+        {"subnet_id": "subnet-web", "routes": {"0.0.0.0/0": "igw-main"}},
+    ],
+    "security_groups": {
+        "sg-web": {"ingress": [{"port": 80, "cidr": "0.0.0.0/0"}]},
+    },
+}
+
+doc = net.to_verification_context(
+    infra,                       # raw topology — the guard verifies this itself
+    "internet",
+    "subnet-web",
+    80,
+    formal_statement="Traffic from internet to subnet-web on port 80 is safe",
+    attestation_token="<token>", # optional; without it VERIFIED degrades to UNVERIFIABLE
+)
+
+print(doc.verdict.value)          # -> VERIFIED / BLOCKED / UNVERIFIABLE
+print(doc.context.decision.admission.value)  # -> ADMIT / DENY
+```
+
+The same pattern holds for every guard:
+
+```python
+IamGuard().to_verification_context(policy, action, resource, context, ...)
+CostGuard().to_verification_context(resources, budget_monthly, ...)
+ArtifactBoundaryGuard().to_verification_context(package_dir=..., pyproject_path=..., ...)
+```
+
+### Using VC documents downstream
+
+```python
+document = vc.to_dict()   # JSON-serializable dict
+
+from qwed_infra.verification_context import is_valid_document, resolve_document_proof_ref
+
+if is_valid_document(document):                 # schema + verdict/admission consistency
+    assert resolve_document_proof_ref(document) # proof_ref resolves against the evidence
+    admission = document["context"]["decision"]["admission"]  # ADMIT or DENY
+```
+
+Store or forward `document` anywhere JSON goes — release gates, pipeline artifacts, audit logs. The `proof_ref` binds the decision to the exact evidence that produced it.
+
+> **Roadmap (#47):** today the attestation token is checked for presence; cryptographic validation and claim binding (signature, issuer, expiry, digest binding à la `enforce_trust_decision`) land with the attestation trust boundary milestone.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -199,11 +199,11 @@ A `True/False` return value is enough for one process — but CI/CD pipelines, r
 
 | Plain result | Verification Context |
 | :--- | :--- |
-| `result.allowed == False` | Signed-off document: claim, verifier identity+version, evidence hash (`proof_ref`), admission decision |
-| Lives only in your process log | JSON-serializable, schema-validated, tamper-evident (`sha256` bound to the evidence) |
+| `result.allowed == False` | Document: claim, verifier identity+version, hash-linked evidence (`proof_ref`), admission decision |
+| Lives only in your process log | JSON-serializable, schema-validated, evidence-bound (`sha256` proof_ref computed over the exact evidence) |
 | No story when someone asks "who verified this?" | `proof.verifier`, `audit_trace`, and rule IDs answer it |
 
-The document is **fail-closed by construction**: anything that is not proven is `DENY` — `UNVERIFIABLE` and `BLOCKED` outcomes can never produce `ADMIT`.
+The document is **fail-closed by construction**: anything that is not proven is `DENY` — `UNVERIFIABLE` and `BLOCKED` outcomes can never produce `ADMIT`. Note that in v1.0 the attestation token is checked for **presence only** — cryptographic validation (signature/issuer/expiry/claim binding) lands with #47.
 
 ### Usage
 
@@ -229,36 +229,52 @@ doc = net.to_verification_context(
     "subnet-web",
     80,
     formal_statement="Traffic from internet to subnet-web on port 80 is safe",
-    attestation_token="<token>", # optional; without it VERIFIED degrades to UNVERIFIABLE
+    # optional; v1.0 checks PRESENCE only (any non-empty string). Without it,
+    # VERIFIED degrades to UNVERIFIABLE. Cryptographic validation: #47.
+    attestation_token="my-release-attestation-v1",
 )
 
 print(doc.verdict.value)          # -> VERIFIED / BLOCKED / UNVERIFIABLE
 print(doc.context.decision.admission.value)  # -> ADMIT / DENY
 ```
 
-The same pattern holds for every guard:
+The same pattern holds for every guard (`formal_statement` is keyword-only and required):
 
 ```python
-IamGuard().to_verification_context(policy, action, resource, context, ...)
-CostGuard().to_verification_context(resources, budget_monthly, ...)
-ArtifactBoundaryGuard().to_verification_context(package_dir=..., pyproject_path=..., ...)
+IamGuard().to_verification_context(policy, action, resource, context,
+                                   formal_statement="IAM policy is safe to apply")
+CostGuard().to_verification_context(resources, budget_monthly,
+                                    formal_statement="Estimated cost is within budget")
+ArtifactBoundaryGuard().to_verification_context(package_dir="mypkg", pyproject_path="pyproject.toml",
+                                                formal_statement="Package boundary is safe to publish")
 ```
 
 ### Using VC documents downstream
 
 ```python
-document = vc.to_dict()   # JSON-serializable dict
-
 from qwed_infra.verification_context import is_valid_document, resolve_document_proof_ref
 
-if is_valid_document(document):                 # schema + verdict/admission consistency
-    assert resolve_document_proof_ref(document) # proof_ref resolves against the evidence
-    admission = document["context"]["decision"]["admission"]  # ADMIT or DENY
+document = doc.to_dict()   # JSON-serializable dict
+
+if not is_valid_document(document):
+    raise ValueError("Invalid VC document — reject")   # schema/verdict inconsistency
+
+admission = document["context"]["decision"]["admission"]   # ADMIT or DENY
+
+if admission == "ADMIT":
+    # VERIFIED documents carry a proof_ref bound to the exact evidence;
+    # require that it resolves before trusting the decision.
+    if not resolve_document_proof_ref(document):
+        raise ValueError("VC document proof_ref does not resolve — reject")
+    # ... proceed with the gated operation ...
+else:
+    # DENY: fail closed. BLOCKED/UNVERIFIABLE documents carry no proof_ref by design.
+    raise PermissionError(f"Verification denied ({document['verdict']}) — reject")
 ```
 
-Store or forward `document` anywhere JSON goes — release gates, pipeline artifacts, audit logs. The `proof_ref` binds the decision to the exact evidence that produced it.
+Store or forward `document` anywhere JSON goes — release gates, pipeline artifacts, audit logs. The `proof_ref` binds a VERIFIED decision to the exact evidence that produced it.
 
-> **Roadmap (#47):** today the attestation token is checked for presence; cryptographic validation and claim binding (signature, issuer, expiry, digest binding à la `enforce_trust_decision`) land with the attestation trust boundary milestone.
+> **Roadmap (#47):** today the attestation token is checked for **presence only**; cryptographic validation and claim binding (signature, issuer, expiry, digest binding à la `enforce_trust_decision`) land with the attestation trust boundary milestone.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -238,7 +238,8 @@ print(doc.verdict.value)          # -> VERIFIED / BLOCKED / UNVERIFIABLE
 print(doc.context.decision.admission.value)  # -> ADMIT / DENY
 ```
 
-The same pattern holds for every guard (`formal_statement` is keyword-only and required):
+The same pattern holds for every guard (`formal_statement` is keyword-only and required).
+Schematic — define `policy`/`resources` etc. as in the guard examples above:
 
 ```python
 IamGuard().to_verification_context(policy, action, resource, context,
@@ -268,11 +269,12 @@ if admission == "ADMIT":
         raise ValueError("VC document proof_ref does not resolve — reject")
     # ... proceed with the gated operation ...
 else:
-    # DENY: fail closed. BLOCKED/UNVERIFIABLE documents carry no proof_ref by design.
+    # DENY: fail closed. BLOCKED/UNVERIFIABLE documents do not require
+    # context.evidence.proof_ref (diagnostic proof hashes are separate).
     raise PermissionError(f"Verification denied ({document['verdict']}) — reject")
 ```
 
-Store or forward `document` anywhere JSON goes — release gates, pipeline artifacts, audit logs. The `proof_ref` binds a VERIFIED decision to the exact evidence that produced it.
+Store or forward `document` anywhere JSON goes — release gates, pipeline artifacts, audit logs. The `proof_ref` binds a VERIFIED decision to the exact evidence that produced it. VC evidence can contain sensitive infrastructure, policy, or cost data — apply your own access control, redaction, and retention rules when storing or forwarding documents downstream.
 
 > **Roadmap (#47):** today the attestation token is checked for **presence only**; cryptographic validation and claim binding (signature, issuer, expiry, digest binding à la `enforce_trust_decision`) land with the attestation trust boundary milestone.
 


### PR DESCRIPTION
## **User description**
## Summary

Closes **#43** — the final tracker-#36 item: documentation for the Verification Context v1.0 rollout.

## Changes

### README.md
- New **"Verification Context v1.0"** section (between Usage Examples and FAQ):
  - **Why VC:** plain booleans vs evidence that travels — claim, verifier identity/version, `sha256`-bound `proof_ref`, ADMIT/DENY admission; fail-closed by construction
  - **Usage examples** with the guard-computes-internally signature (`NetworkGuard.to_verification_context(infra, "internet", "subnet-web", 80, formal_statement=..., attestation_token=...)`) plus the one-line pattern for IamGuard/CostGuard/ArtifactBoundaryGuard
  - **Downstream integration guide:** `vc.to_dict()`, `is_valid_document`, `resolve_document_proof_ref`, reading `admission` from the document — store/forward anywhere JSON goes
  - **Roadmap note (#47):** attestation token is presence-checked today; cryptographic validation + claim binding land with the attestation trust boundary milestone
- **VC v1.0 badge** added to the header badge row

### CHANGELOG.md
- `[Unreleased]` entry documenting:
  - The full tracker #36 rollout (bridge #37/#44, four guard adapters #38–#41, conformance suite #42)
  - The **pre-1.0 breaking change**: result-based adapter signatures removed in favor of raw-input guard-computes-internally signatures (forgeable results could mint ADMIT)
  - The fail-closed hardening fixes from the review rounds (malformed inputs, symlink escapes, backend allowlist, content manifests, IAM verified-denial demotion)

## Verification

- Docs-only change; full suite still **485 passed / 4 skipped**
- No code changes


___

## **CodeAnt-AI Description**
Document Verification Context v1.0 and its fail-closed trust decisions

### What Changed
- Added a README guide explaining how guards produce portable, machine-checkable Verification Context documents with evidence, verifier details, and ADMIT/DENY decisions
- Added usage examples for all four guards, including downstream validation, JSON storage, and proof-reference resolution
- Documented that guards verify raw inputs themselves instead of accepting caller-supplied results
- Added the Verification Context v1.0 badge and an Unreleased changelog covering the rollout, breaking API change, and fail-closed handling of malformed or unsafe inputs

### Impact
`✅ Clearer Verification Context integration`
`✅ Traceable verification decisions in pipelines and audit logs`
`✅ Explicit fail-closed behavior for unverifiable or malformed input`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added Verification Context v1.0 guidance for portable, machine-checkable verification artifacts.
  - Documented fail-closed decisions, guard-specific generation, validation, proof-reference resolution, and attestation-token checks.
  - Clarified guard API usage and rejection handling for invalid, unverifiable, blocked, or unresolved-proof documents.
  - Added a Verification Context badge.
  - Clarified IAM denial diagnostics and document-level proof references for DENY decisions.
  - Added guidance on protecting, redacting, and retaining sensitive verification evidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->