### PR TITLE
chore(release): v0.3.0 - Verification Context v1.0 + attestation trust boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.3.0] - 2026-08-24
 
 ### Added
 - Verification Context v1.0 across all four guards (tracker #36) — every guard now exposes `to_verification_context()`, producing a schema-valid, tamper-evident VC document (claim, verifier identity, `sha256`-bound evidence `proof_ref`, ADMIT/DENY admission):
@@ -8,9 +8,13 @@
   - Shared bridge module `verification_context_bridge` (#37, PR #44): diagnostic → VC document conversion with fail-closed attestation policy and decision-status demotion
   - Conformance suite `tests/test_vc_conformance.py` (#42, PR #52) — bridge + all guards + document validation + malformed-input fail-closed acceptance tests
   - README: "Verification Context v1.0" section — why VC, usage examples, downstream integration guide; VC badge in the header
+- **Attestation trust boundary (#47, PR #54)** — new `qwed_infra/attestation.py`: ES256 (ECDSA P-256) JWT attestation service with ephemeral key lifecycle auditing, revocation registry, and the never-None fail-closed `AttestationResult` contract; `enforce_trust_decision()` in diagnostics.py as the single consumption-side gate validating signature/issuer/expiry/revocation plus claim bindings (status match, `query_hash == sha256(formal_statement)`, `proof_hash == diagnostic proof_ref`)
+- `mint_diagnostic_attestation()` — issues a token bound to a diagnostic's own evidence commitment
 
 ### Changed
-- **BREAKING (pre-1.0, unreleased API):** guard adapters no longer accept pre-computed result objects. `to_verification_context()` takes **raw verification inputs** and runs the guard's own deterministic solver internally (`NetworkGuard.to_verification_context(resources, source, destination, port, ...)` / `IamGuard.to_verification_context(policy, action, resource, context, ...)` / `CostGuard.to_verification_context(resources, budget_monthly, ...)` / `ArtifactBoundaryGuard.to_verification_context(package_dir, ...)`) — a result-accepting signature is forgeable (a caller could fabricate a positive result and mint ADMIT), so it was removed before any release (PRs #45/#46/#48/#50)
+- **BREAKING (pre-1.0, unreleased API):** guard adapters no longer accept pre-computed result objects. `to_verification_context()` takes **raw verification inputs** and runs the guard's own deterministic solver internally (`NetworkGuard.to_verification_context(resources, source, destination, port, ...)` / `IamGuard.to_verification_context(policy, action, resource, context=None, ...)` / `CostGuard.to_verification_context(resources, budget_monthly, ...)` / `ArtifactBoundaryGuard.to_verification_context(package_dir, ...)`) — a result-accepting signature is forgeable (a caller could fabricate a positive result and mint ADMIT), so it was removed before any release (PRs #45/#46/#48/#50)
+- **ADMISSION SEMANTICS:** `VERIFIED` results now admit **only** with a cryptographically valid attestation bound to the exact claim and evidence. Arbitrary non-empty attestation strings no longer grant ADMIT (they are rejected as forged tokens); a missing token demotes VERIFIED to UNVERIFIABLE/DENY. Callers previously passing placeholder tokens must mint via `create_verification_attestation()` / `mint_diagnostic_attestation()`
+- New runtime dependencies: `pyjwt>=2.8.0,!=2.12.1`, `cryptography>=41.0.0`
 
 ### Fixed
 - Fail-closed on malformed inputs at every VC boundary: undecimal budgets, extreme Decimal values, non-string build backends, malformed topology/policy/package inputs, symlink escapes/loops, wheel entries outside the scanned boundary — all map to BLOCKED/DENY documents instead of exceptions or guessed approval (#48, #49/PR #51, #50)

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ A `True/False` return value is enough for one process — but CI/CD pipelines, r
 | Lives only in your process log | JSON-serializable, schema-validated, evidence-bound (`sha256` proof_ref computed over the exact evidence) |
 | No story when someone asks "who verified this?" | `proof.verifier`, `audit_trace`, and rule IDs answer it |
 
-The document is **fail-closed by construction**: anything that is not proven is `DENY` — `UNVERIFIABLE` and `BLOCKED` outcomes can never produce `ADMIT`. Note that in v1.0 the attestation token is checked for **presence only** — cryptographic validation (signature/issuer/expiry/claim binding) lands with #47.
+The document is **fail-closed by construction**: anything that is not proven is `DENY` — `UNVERIFIABLE` and `BLOCKED` outcomes can never produce `ADMIT`. Attestations are **cryptographically validated** (ES256 signature, issuer, expiry, revocation) and bound to the exact claim and evidence (`query_hash`, `proof_hash`) — a token minted for one statement can never admit another.
 
 ### Usage
 
@@ -211,6 +211,7 @@ Each guard runs its own verification internally and returns a VC document. You p
 
 ```python
 from qwed_infra import NetworkGuard
+from qwed_infra.attestation import mint_diagnostic_attestation
 
 net = NetworkGuard()
 infra = {
@@ -223,15 +224,26 @@ infra = {
     },
 }
 
+statement = "Traffic from internet to subnet-web on port 80 is safe"
+
+# Mint an attestation bound to THIS claim + evidence (the guard computes the
+# same check internally; the token's proof_hash must match its commitment).
+diagnostic = NetworkGuard.to_diagnostic(
+    net.verify_reachability(infra, "internet", "subnet-web", 80)
+)
+attestation = mint_diagnostic_attestation(
+    diagnostic, engine="NetworkGuard", query=statement
+)
+
 doc = net.to_verification_context(
     infra,                       # raw topology — the guard verifies this itself
     "internet",
     "subnet-web",
     80,
-    formal_statement="Traffic from internet to subnet-web on port 80 is safe",
-    # optional; v1.0 checks PRESENCE only (any non-empty string). Without it,
-    # VERIFIED degrades to UNVERIFIABLE. Cryptographic validation: #47.
-    attestation_token="my-release-attestation-v1",
+    formal_statement=statement,
+    # optional; without it VERIFIED degrades to UNVERIFIABLE/DENY.
+    # A forged, expired, revoked, or non-matching token BLOCKS.
+    attestation_token=attestation.token,
 )
 
 print(doc.verdict.value)          # -> VERIFIED / BLOCKED / UNVERIFIABLE
@@ -276,7 +288,7 @@ else:
 
 Store or forward `document` anywhere JSON goes — release gates, pipeline artifacts, audit logs. The `proof_ref` binds a VERIFIED decision to the exact evidence that produced it. VC evidence can contain sensitive infrastructure, policy, or cost data — apply your own access control, redaction, and retention rules when storing or forwarding documents downstream.
 
-> **Roadmap (#47):** today the attestation token is checked for **presence only**; cryptographic validation and claim binding (signature, issuer, expiry, digest binding à la `enforce_trust_decision`) land with the attestation trust boundary milestone.
+> **Attestation trust model:** attestations are self-signed by the guard process (ES256, ephemeral key) and cryptographically validated at the admission boundary — signature, issuer, expiry, revocation, plus binding to the exact claim and evidence. This is the interim stage on the path to an external witness/transparency log (ADR-005 in qwed-verification); multi-replica deployments require shared signing keys until replica-key resolution exists.
 
 ---
 
@@ -296,8 +308,9 @@ A: We use public On-Demand pricing for "Worst Case" estimation. If you have Ente
 ## 🗺️ Roadmap
 
 *   ✅ **v0.1.0:** IAM Z3 Logic, Basic Network Graph, Static Cost Catalog. (Released Jan 2025)
-*   ✅ **v0.2.0:** Fail-closed parser + IAM, NetworkGuard CIDR fix, CI fail-open removal, diagnostic port (audit.py/InfraDiagnosticResult), CostGuard Decimal/unknown types, ArtifactBoundaryGuard. (Current)
-*   🔮 **v0.3.0:** Docker/deployment artifact verification, K8s manifest support, Azure provider.
+*   ✅ **v0.2.0:** Fail-closed parser + IAM, NetworkGuard CIDR fix, CI fail-open removal, diagnostic port (audit.py/InfraDiagnosticResult), CostGuard Decimal/unknown types, ArtifactBoundaryGuard.
+*   ✅ **v0.3.0:** Verification Context v1.0 across all four guards (bridge, `to_verification_context()` adapters, conformance suite) + attestation trust boundary — ES256-signed receipts bound to the exact claim and evidence gate every ADMIT. (Current)
+*   🔮 Next: Docker/deployment artifact verification, K8s manifest support, Azure provider.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,9 @@ diagnostic = NetworkGuard.to_diagnostic(
 attestation = mint_diagnostic_attestation(
     diagnostic, engine="NetworkGuard", query=statement
 )
+if not attestation.is_issued:
+    # fail-closed contract: never proceed on an unissued attestation
+    raise RuntimeError(f"Attestation unavailable [{attestation.error_code}]")
 
 doc = net.to_verification_context(
     infra,                       # raw topology — the guard verifies this itself

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "qwed-infra"
-version = "0.2.0"
+version = "0.3.0"
 description = "Deterministic Verification for Infrastructure as Code (IaC) using Z3 and Graph Theory."
 authors = [
     {name = "QWED Team", email = "rahul@qwedai.com"},

--- a/qwed_infra/__init__.py
+++ b/qwed_infra/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 from .guards.iam_guard import IamGuard
 from .guards.network_guard import NetworkGuard

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=QWED-AI_qwed-infra
 sonar.organization=qwed-ai
 
 sonar.projectName=QWED Infra
-sonar.projectVersion=0.2.0
+sonar.projectVersion=0.3.0
 
 # Source directories
 sonar.sources=qwed_infra


### PR DESCRIPTION
## Summary

Pre-release preparation for **v0.3.0** — "Verification Context v1.0 + Attestation Trust Boundary". No production logic changes; version metadata, release notes, and documentation accuracy only.

## Version bumps (0.2.0 → 0.3.0)

| File | Change |
|---|---|
| `pyproject.toml` | `version = "0.3.0"` (drives PyPI + build) |
| `sonar-project.properties` | `sonar.projectVersion=0.3.0` |
| `qwed_infra/__init__.py` | `__version__ = "0.3.0"` |

## CHANGELOG.md

- `[Unreleased]` finalized as **`[0.3.0] - 2026-08-24`**
- New **ADMISSION SEMANTICS** bullet under *Changed*: VERIFIED admits only with a cryptographically valid attestation bound to the exact claim+evidence; placeholder tokens now BLOCK; callers must mint via `create_verification_attestation()` / `mint_diagnostic_attestation()`
- New *Changed* entry for the runtime dependencies (`pyjwt`, `cryptography`)
- *Added* gains the #47/PR #54 attestation entries

## README.md — post-#47 accuracy

All three stale "presence-only attestation" statements updated to the shipped cryptographic reality:
- Why-VC paragraph: attestations are ES256-validated and bound to claim+evidence
- NetworkGuard usage example: full mint flow (`verify_reachability` → `to_diagnostic` → `mint_diagnostic_attestation` → `attestation.token`) — **verified runnable end-to-end** against the package
- Roadmap note replaced with the attestation trust model (self-signed interim stage per ADR-005; multi-replica caveat)
- Version history: v0.3.0 marked Current; deferred Docker/K8s/Azure items moved to "Next"

## npm / SDK note

No npm package exists for qwed-infra ("coming soon" in README) — nothing to bump there. PyPI publishing is automated via `publish.yml` (triggers on GitHub Release published).

## After merge

1. Create GitHub Release **v0.3.0** on `main` (tag + notes from CHANGELOG)
2. `publish.yml` builds and publishes to PyPI automatically
3. Verify PyPI metadata resolves with the new dependencies

## Verification

- Full suite: **513 passed**, 4 skipped
- README examples verified runnable
- Docs/metadata-only change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added cryptographic attestations for diagnostic evidence using signed, expiring tokens.
  - Added attestation revocation support and lifecycle auditing.
  - Added safeguards binding attestations to the exact claim and evidence.

- **Bug Fixes**
  - Invalid, forged, expired, revoked, or missing attestations are rejected.
  - Verification now fails closed instead of accepting unverifiable claims.

- **Documentation**
  - Updated verification guidance, examples, trust model, and roadmap for version 0.3.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->