### PR TITLE
fix: pin hatchling + bump pypi-publish (Metadata-Version 2.5 publish failure)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,4 +26,8 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # release/v1
+      # v1.14.2 (twine >= 7): the older release/v1 pin ships twine < 7,
+      # which rejects Metadata-Version 2.5 emitted by floating hatchling.
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+      with:
+        skip-existing: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ Issues = "https://github.com/QWED-AI/qwed-infra/issues"
 Changelog = "https://github.com/QWED-AI/qwed-infra/blob/main/CHANGELOG.md"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling==1.27.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
## Summary

Release hotfix: the **v0.3.0 PyPI publish failed** in `gh-action-pypi-publish`'s `verify_metadata` step — `Invalid distribution metadata: '2.5' is not a valid metadata version`.

**Root cause** (identical to qwed-verification #318): `[build-system] requires = ["hatchling"]` floated to hatchling 1.32.x, which emits `Metadata-Version 2.5`; the pinned `pypa/gh-action-pypi-publish@ed0c539` (release/v1) image ships twine < 7, which only accepts up to 2.4.

## Fix (mirrors qwed-verification #318)

1. **Pin `hatchling==1.27.0`** — emits Metadata-Version 2.4 (broadly supported); builds become reproducible and metadata stops floating.
2. **Bump `pypa/gh-action-pypi-publish` to `v1.14.2`** (`dc37677…`, twine ≥ 7, supports Metadata-Version 2.5 incl. PEP 794) — defense-in-depth for future backend bumps.
3. **`skip-existing: true`** — retry attempts after a partial upload no longer fail on PyPI's immutable-artifact rule.

## Verification

- Local build with the pin produces `Metadata-Version: 2.4` (inspected wheel METADATA)
- Full suite: **513 passed**, 4 skipped
- `dist/` artifacts gitignored; nothing committed from local builds

## Release recovery plan (after merge)

The existing `v0.3.0` tag/release points at the pre-fix commit, and its artifact can never pass validation. Plan:
1. Merge this PR
2. Delete the failed v0.3.0 release + tag
3. Recreate release `v0.3.0` at the fixed `main` → `publish.yml` re-runs with the pinned build → PyPI publish succeeds
